### PR TITLE
Добавление кастомизации сотрудников ЦК.

### DIFF
--- a/Resources/Prototypes/Backmen/Adminbuse/centcomm_officers.yml
+++ b/Resources/Prototypes/Backmen/Adminbuse/centcomm_officers.yml
@@ -81,6 +81,7 @@
     ears: ClothingHeadsetAltCentCom
     pocket1: CyberPen
     pocket2: BoxFolderSecretBlack
+  innerclothingskirt: ClothingUniformJumpskirtCentcomOfficer
 
 - type: entity
   noSpawn: true
@@ -152,10 +153,14 @@
   id: OperatorGavna
   equipment:
     jumpsuit: ClothingUniformJumpsuitCentcomOfficer
+    back: ClothingBackpackFilled
     shoes: ClothingShoesBootsLaceup
     id: CCOperatorPDA
     ears: ClothingHeadsetCentCom
     pocket1: ClothingMaskGasCentcom
+  innerclothingskirt: ClothingUniformJumpskirtCentcomOfficer
+  satchel: ClothingBackpackSatchelFilled
+  duffelbag: ClothingBackpackDuffelFilled
 
 - type: entity
   name:  Оператор Центрального Командования
@@ -241,6 +246,7 @@
   id: OfficerSesurity
   equipment:
     jumpsuit: ClothingUniformJumpsuitHoSAlt
+    back: ClothingBackpackSecurityFilled
     shoes: ClothingShoesBootsNedoSpetsnaz
     mask: ClothingMaskGasSecurity
     neck: CombatKnifeSpetsnaz
@@ -253,6 +259,9 @@
     ears: ClothingHeadsetCentComCC
     belt: ClothingBeltSecuritySuper
     pocket2: MagazinePistol
+  innerclothingskirt: ClothingUniformJumpskirtHoSAlt
+  satchel: ClothingBackpackSatchelSecurityFilled
+  duffelbag: ClothingBackpackDuffelSecurityFilled
 
 - type: entity
   name:  Охрана ЦК

--- a/Resources/Prototypes/Backmen/Adminbuse/centcomm_officers.yml
+++ b/Resources/Prototypes/Backmen/Adminbuse/centcomm_officers.yml
@@ -207,6 +207,25 @@
     jobTitle: Офицер Специальной СБ
 
 - type: entity
+  parent: CentcomPDABackmen
+  id: CCOfficerPDA
+  name: Centcom Officer PDA
+  description: Light green sign of walking bureaucracy.
+  components:
+    - type: Pda
+      id: IDCardCentComGavnaOfficerSesurity
+      state: pda-centcom
+      penSlot:
+        startingItem: PenCentcom
+        whitelist:
+          tags:
+            - Write
+    - type: PdaBorderColor
+      borderColor: "#00842e"
+    - type: Icon
+      state: pda-centcom
+
+- type: entity
   name: дубинка-шокер спецсил
   parent: Stunbaton
   id: StunbatonSuper
@@ -255,7 +274,7 @@
     outerClothing: ClothingOuterArmorBasic
     suitstorage: WeaponPistolMk58
     head: ClothingHeadHatBeretHoS
-    id: IDCardCentComGavnaOfficerSesurity
+    id: CCOfficerPDA
     ears: ClothingHeadsetCentComCC
     belt: ClothingBeltSecuritySuper
     pocket2: MagazinePistol

--- a/Resources/Prototypes/Backmen/Adminbuse/centcomm_officers.yml
+++ b/Resources/Prototypes/Backmen/Adminbuse/centcomm_officers.yml
@@ -133,7 +133,7 @@
 - type: entity
   parent: CentcomPDABackmen
   id: CCOperatorPDA
-  name: Centcom Cargo PDA
+  name: Centcom Operator PDA
   description: Light green sign of walking bureaucracy.
   components:
     - type: Pda


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Добавлена возможность выбора одежды,у ОССБ и у ОЦК со старта есть место для хранения(у ПЦК вообще БС сумка в кабинете и наличие отдельной сумки будет только мешать),мелкий багфикс,ОССБ теперь имеет КПК

**Медиа**
![ОССБ феленид с юбкой,сумкой и КПК со старта](https://cdn.discordapp.com/attachments/1128445526933770260/1133029304855429160/image.png)

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят.

В журнал изменений следует помещать только то, что действительно важно игрокам.

В списке изменений тип значка не является часть предложения, поэтому явно указывайте - Добавлен, Удалён, Изменён.
плохо: - add: Новый инструмент для инженеров
хорошо: - add: Добавлен новый инструмент для инженеров

Вы можете указать своё имя после символа :cl: именно оно будет отображаться в журнале изменений (иначе будет использоваться ваше имя на GitHub)
Например: :cl: Ian

-->

:cl:
- add: КПК ОССБ.
- tweak:Теперь песонажи ЦК имеют возможность начинать с юбками.
- tweak:ОЦК и ОССБ теперь начинают с рюкзаками(кастомизация в наличии)
- fix: КПК ОЦК был переименован с Centcom Cargo PDA в Cencom Operator PDA
