### PR TITLE
Фикс баланс Атмосии

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -6,6 +6,9 @@
     mode: SnapgridCenter
   components:
     - type: AtmosDevice
+    - type: Tag
+      tags:
+        - Unstackable
     - type: SubFloorHide
       blockInteractions: false
       blockAmbience: false
@@ -53,6 +56,7 @@
     - type: Tag
       tags:
         - GasVent
+        - Unstackable
     - type: Sprite
       drawdepth: FloorObjects
       sprite: Structures/Piping/Atmospherics/vent.rsi
@@ -143,6 +147,7 @@
     - type: Tag
       tags:
         - GasScrubber
+        - Unstackable
     - type: Sprite
       drawdepth: FloorObjects
       sprite: Structures/Piping/Atmospherics/scrubber.rsi

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -6,9 +6,6 @@
     mode: SnapgridCenter
   components:
     - type: AtmosDevice
-    - type: Tag
-      tags:
-        - Unstackable
     - type: SubFloorHide
       blockInteractions: false
       blockAmbience: false
@@ -56,7 +53,6 @@
     - type: Tag
       tags:
         - GasVent
-        - Unstackable
     - type: Sprite
       drawdepth: FloorObjects
       sprite: Structures/Piping/Atmospherics/vent.rsi
@@ -147,7 +143,6 @@
     - type: Tag
       tags:
         - GasScrubber
-        - Unstackable
     - type: Sprite
       drawdepth: FloorObjects
       sprite: Structures/Piping/Atmospherics/scrubber.rsi

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -6,9 +6,9 @@
     mode: SnapgridCenter
   components:
     - type: AtmosDevice
-    - type: Tag
-      tags:
-        - Unstackable
+#    - type: Tag
+#      tags:
+#        - Unstackable
     - type: SubFloorHide
       blockInteractions: false
       blockAmbience: false
@@ -56,7 +56,7 @@
     - type: Tag
       tags:
         - GasVent
-        - Unstackable
+#        - Unstackable
     - type: Sprite
       drawdepth: FloorObjects
       sprite: Structures/Piping/Atmospherics/vent.rsi
@@ -147,7 +147,7 @@
     - type: Tag
       tags:
         - GasScrubber
-        - Unstackable
+#        - Unstackable
     - type: Sprite
       drawdepth: FloorObjects
       sprite: Structures/Piping/Atmospherics/scrubber.rsi

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -445,7 +445,8 @@
     state: vent_off
   conditions:
     - !type:TileNotBlocked {}
-
+    - !type:NoUnstackableInTile
+    
 - type: construction
   name: passive vent
   description: Unpowered vent that equalises gases on both sides.
@@ -466,7 +467,8 @@
     state: vent_off
   conditions:
     - !type:TileNotBlocked {}
-
+    - !type:NoUnstackableInTile
+    
 - type: construction
   name: air scrubber
   description: Sucks gas into connected pipes.
@@ -487,7 +489,8 @@
     state: scrub_off
   conditions:
     - !type:TileNotBlocked {}
-
+    - !type:NoUnstackableInTile
+    
 - type: construction
   name: air injector
   description: Injects air into the atmosphere.
@@ -508,7 +511,8 @@
     state: injector
   conditions:
     - !type:TileNotBlocked {}
-
+    - !type:NoUnstackableInTile
+    
 # ATMOS BINARY
 - type: construction
   name: gas pump
@@ -530,6 +534,7 @@
     state: pumpPressure
   conditions:
     - !type:TileNotBlocked {}
+    - !type:NoUnstackableInTile
 
 - type: construction
   name: volumetric gas pump
@@ -551,6 +556,7 @@
     state: pumpVolume
   conditions:
     - !type:TileNotBlocked {}
+    - !type:NoUnstackableInTile
 
 - type: construction
   id: GasPassiveGate
@@ -572,6 +578,7 @@
     state: pumpPassiveGate
   conditions:
     - !type:TileNotBlocked {}
+    - !type:NoUnstackableInTile
 
 - type: construction
   id: GasValve
@@ -593,6 +600,7 @@
     state: pumpManualValve
   conditions:
     - !type:TileNotBlocked {}
+    - !type:NoUnstackableInTile
 
 - type: construction
   id: SignalControlledValve
@@ -614,6 +622,7 @@
     state: pumpSignalValve
   conditions:
   - !type:TileNotBlocked {}
+  - !type:NoUnstackableInTile
 
 - type: construction
   id: GasPort
@@ -635,6 +644,7 @@
     state: gasCanisterPort
   conditions:
     - !type:TileNotBlocked {}
+    - !type:NoUnstackableInTile
 
 - type: construction
   id: GasDualPortVentPump
@@ -690,6 +700,7 @@
   mirror: GasFilterFlipped
   conditions:
     - !type:TileNotBlocked {}
+    - !type:NoUnstackableInTile
 
 - type: construction
   id: GasFilterFlipped
@@ -708,6 +719,7 @@
   mirror: GasFilter
   conditions:
     - !type:TileNotBlocked {}
+    - !type:NoUnstackableInTile
 
 - type: construction
   id: GasMixer
@@ -725,6 +737,7 @@
   mirror: GasMixerFlipped
   conditions:
     - !type:TileNotBlocked {}
+    - !type:NoUnstackableInTile
 
 - type: construction
   id: GasMixerFlipped
@@ -743,6 +756,7 @@
   mirror: GasMixer
   conditions:
     - !type:TileNotBlocked
+    - !type:NoUnstackableInTile
 
 - type: construction
   id: PressureControlledValve
@@ -759,6 +773,7 @@
     state: off
   conditions:
     - !type:TileNotBlocked
+    - !type:NoUnstackableInTile
 
 # INTERCOM
 - type: construction

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -445,8 +445,7 @@
     state: vent_off
   conditions:
     - !type:TileNotBlocked {}
-    - !type:NoUnstackableInTile
-    
+
 - type: construction
   name: passive vent
   description: Unpowered vent that equalises gases on both sides.
@@ -467,8 +466,7 @@
     state: vent_off
   conditions:
     - !type:TileNotBlocked {}
-    - !type:NoUnstackableInTile
-    
+
 - type: construction
   name: air scrubber
   description: Sucks gas into connected pipes.
@@ -489,8 +487,7 @@
     state: scrub_off
   conditions:
     - !type:TileNotBlocked {}
-    - !type:NoUnstackableInTile
-    
+
 - type: construction
   name: air injector
   description: Injects air into the atmosphere.
@@ -511,8 +508,7 @@
     state: injector
   conditions:
     - !type:TileNotBlocked {}
-    - !type:NoUnstackableInTile
-    
+
 # ATMOS BINARY
 - type: construction
   name: gas pump
@@ -534,7 +530,6 @@
     state: pumpPressure
   conditions:
     - !type:TileNotBlocked {}
-    - !type:NoUnstackableInTile
 
 - type: construction
   name: volumetric gas pump
@@ -556,7 +551,6 @@
     state: pumpVolume
   conditions:
     - !type:TileNotBlocked {}
-    - !type:NoUnstackableInTile
 
 - type: construction
   id: GasPassiveGate
@@ -578,7 +572,6 @@
     state: pumpPassiveGate
   conditions:
     - !type:TileNotBlocked {}
-    - !type:NoUnstackableInTile
 
 - type: construction
   id: GasValve
@@ -600,7 +593,6 @@
     state: pumpManualValve
   conditions:
     - !type:TileNotBlocked {}
-    - !type:NoUnstackableInTile
 
 - type: construction
   id: SignalControlledValve
@@ -622,7 +614,6 @@
     state: pumpSignalValve
   conditions:
   - !type:TileNotBlocked {}
-  - !type:NoUnstackableInTile
 
 - type: construction
   id: GasPort
@@ -644,7 +635,6 @@
     state: gasCanisterPort
   conditions:
     - !type:TileNotBlocked {}
-    - !type:NoUnstackableInTile
 
 - type: construction
   id: GasDualPortVentPump
@@ -700,7 +690,6 @@
   mirror: GasFilterFlipped
   conditions:
     - !type:TileNotBlocked {}
-    - !type:NoUnstackableInTile
 
 - type: construction
   id: GasFilterFlipped
@@ -719,7 +708,6 @@
   mirror: GasFilter
   conditions:
     - !type:TileNotBlocked {}
-    - !type:NoUnstackableInTile
 
 - type: construction
   id: GasMixer
@@ -737,7 +725,6 @@
   mirror: GasMixerFlipped
   conditions:
     - !type:TileNotBlocked {}
-    - !type:NoUnstackableInTile
 
 - type: construction
   id: GasMixerFlipped
@@ -756,7 +743,6 @@
   mirror: GasMixer
   conditions:
     - !type:TileNotBlocked
-    - !type:NoUnstackableInTile
 
 - type: construction
   id: PressureControlledValve
@@ -773,7 +759,6 @@
     state: off
   conditions:
     - !type:TileNotBlocked
-    - !type:NoUnstackableInTile
 
 # INTERCOM
 - type: construction

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -445,8 +445,8 @@
     state: vent_off
   conditions:
     - !type:TileNotBlocked {}
-    - !type:NoUnstackableInTile
-    
+#    - !type:NoUnstackableInTile
+
 - type: construction
   name: passive vent
   description: Unpowered vent that equalises gases on both sides.
@@ -467,8 +467,8 @@
     state: vent_off
   conditions:
     - !type:TileNotBlocked {}
-    - !type:NoUnstackableInTile
-    
+#    - !type:NoUnstackableInTile
+
 - type: construction
   name: air scrubber
   description: Sucks gas into connected pipes.
@@ -489,8 +489,8 @@
     state: scrub_off
   conditions:
     - !type:TileNotBlocked {}
-    - !type:NoUnstackableInTile
-    
+#    - !type:NoUnstackableInTile
+
 - type: construction
   name: air injector
   description: Injects air into the atmosphere.
@@ -511,8 +511,8 @@
     state: injector
   conditions:
     - !type:TileNotBlocked {}
-    - !type:NoUnstackableInTile
-    
+#    - !type:NoUnstackableInTile
+
 # ATMOS BINARY
 - type: construction
   name: gas pump
@@ -534,7 +534,7 @@
     state: pumpPressure
   conditions:
     - !type:TileNotBlocked {}
-    - !type:NoUnstackableInTile
+#    - !type:NoUnstackableInTile
 
 - type: construction
   name: volumetric gas pump
@@ -556,7 +556,7 @@
     state: pumpVolume
   conditions:
     - !type:TileNotBlocked {}
-    - !type:NoUnstackableInTile
+#    - !type:NoUnstackableInTile
 
 - type: construction
   id: GasPassiveGate
@@ -578,7 +578,7 @@
     state: pumpPassiveGate
   conditions:
     - !type:TileNotBlocked {}
-    - !type:NoUnstackableInTile
+#    - !type:NoUnstackableInTile
 
 - type: construction
   id: GasValve
@@ -600,7 +600,7 @@
     state: pumpManualValve
   conditions:
     - !type:TileNotBlocked {}
-    - !type:NoUnstackableInTile
+#    - !type:NoUnstackableInTile
 
 - type: construction
   id: SignalControlledValve
@@ -622,7 +622,7 @@
     state: pumpSignalValve
   conditions:
   - !type:TileNotBlocked {}
-  - !type:NoUnstackableInTile
+#  - !type:NoUnstackableInTile
 
 - type: construction
   id: GasPort
@@ -644,7 +644,7 @@
     state: gasCanisterPort
   conditions:
     - !type:TileNotBlocked {}
-    - !type:NoUnstackableInTile
+#    - !type:NoUnstackableInTile
 
 - type: construction
   id: GasDualPortVentPump
@@ -700,7 +700,7 @@
   mirror: GasFilterFlipped
   conditions:
     - !type:TileNotBlocked {}
-    - !type:NoUnstackableInTile
+#    - !type:NoUnstackableInTile
 
 - type: construction
   id: GasFilterFlipped
@@ -719,7 +719,7 @@
   mirror: GasFilter
   conditions:
     - !type:TileNotBlocked {}
-    - !type:NoUnstackableInTile
+#    - !type:NoUnstackableInTile
 
 - type: construction
   id: GasMixer
@@ -737,7 +737,7 @@
   mirror: GasMixerFlipped
   conditions:
     - !type:TileNotBlocked {}
-    - !type:NoUnstackableInTile
+#    - !type:NoUnstackableInTile
 
 - type: construction
   id: GasMixerFlipped
@@ -756,7 +756,7 @@
   mirror: GasMixer
   conditions:
     - !type:TileNotBlocked
-    - !type:NoUnstackableInTile
+#    - !type:NoUnstackableInTile
 
 - type: construction
   id: PressureControlledValve
@@ -773,7 +773,7 @@
     state: off
   conditions:
     - !type:TileNotBlocked
-    - !type:NoUnstackableInTile
+#    - !type:NoUnstackableInTile
 
 # INTERCOM
 - type: construction


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Причина:
Стаканье скрубберов очень важная вещь в атмосе. Без неё тритийварки станут крайне бесполезными ведь не смогут выжимать и моли газа. Так что я вернула стаканье скрубберов, инжекторов и т.д.

**Медиа**
![image](https://github.com/Rxup/space-station-14/assets/140620960/8b5f5288-b4ad-4591-b833-56221b2dfb9e)


**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl:KTDR
- tweak: Изменена возможность стакать скрубберы
