### PR TITLE
Замена крюзимова на НТ Дефолт

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -75,7 +75,7 @@
   - type: EmagSiliconLaw
     stunTime: 5
   - type: SiliconLawProvider
-    laws: Crewsimov
+    laws: NTDefault
   - type: IonStormTarget
   - type: Strippable
   - type: InventorySlots


### PR DESCRIPTION
Замена крюзимова на НТ Дефолт
Вопрос зачем? А все просто, кому то лень нахуй доделать нормально правила для боргов. Данные законы устраняют данную проблему.