### PR TITLE
Emag vendors

### DIFF
--- a/Resources/Locale/ru-RU/backmen/store/category.ftl
+++ b/Resources/Locale/ru-RU/backmen/store/category.ftl
@@ -2,3 +2,4 @@
 store-category-HappyHonk = Oбеды
 store-category-emag = Контрабанда
 store-category-vending-drinks = Hапитки
+store-category-vendingcigs = Сигареты

--- a/Resources/Locale/ru-RU/backmen/store/category.ftl
+++ b/Resources/Locale/ru-RU/backmen/store/category.ftl
@@ -1,2 +1,4 @@
 ﻿store-category-lootbox = Лутбоксы
-store-category-lootbox-emag = Лутбоксы (контрабанда)
+store-category-HappyHonk = Oбеды
+store-category-emag = Контрабанда
+store-category-vending-drinks = Hапитки

--- a/Resources/Prototypes/Backmen/Catalog/VendingMachines/emag_catalog.yml
+++ b/Resources/Prototypes/Backmen/Catalog/VendingMachines/emag_catalog.yml
@@ -1,0 +1,45 @@
+# Drinks
+- type: listing
+  id: DrinkInventoryEmag1
+  productEntity: DrinkNukieCan
+  cost:
+    SpaceCash: 30
+  categories:
+    - DrinkVendInventoryEmag
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 2
+
+- type: listing
+  id: DrinkInventoryEmag2
+  productEntity: DrinkChangelingStingCan
+  cost:
+    SpaceCash: 30
+  categories:
+    - DrinkVendInventoryEmag
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 2
+
+# Happy honk
+- type: listing
+  id: HappyHonkInventoryEmag1
+  productEntity: HappyHonkNukie
+  cost:
+    SpaceCash: 100
+  categories:
+    - HappyHonkInventoryEmag
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 1
+
+- type: listing
+  id: HappyHonkInventoryEmag2
+  productEntity: HappyHonkCluwne
+  cost:
+    SpaceCash: 100
+  categories:
+    - HappyHonkInventoryEmag
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 1

--- a/Resources/Prototypes/Backmen/Catalog/VendingMachines/emag_catalog.yml
+++ b/Resources/Prototypes/Backmen/Catalog/VendingMachines/emag_catalog.yml
@@ -43,3 +43,27 @@
   conditions:
     - !type:ListingLimitedStockCondition
       stock: 1
+
+# Cigs
+- type: listing
+  id: CigaretteMachineInventoryEmag1
+  productEntity: CigPackSyndicate
+  cost:
+    SpaceCash: 50
+  categories:
+    - CigaretteMachineInventoryEmag
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 1
+
+# Coffee
+- type: listing
+  id: HotDrinksMachineInventoryEmag1
+  productEntity: DrinkNothing
+  cost:
+    SpaceCash: 30
+  categories:
+    - HotDrinksMachineInventoryEmag
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 2

--- a/Resources/Prototypes/Backmen/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Backmen/Entities/Structures/Machines/vending_machines.yml
@@ -25,7 +25,7 @@
   id: BackmenVendingLootBox
   name: ЛутБоксы
   suffix: backmen
-  description: 123
+  description: Испытайте удачу и откройте свой лутбокс!
   components:
     - type: VendingMachine
       pack: VendingLootboxInventory
@@ -105,6 +105,8 @@
       balance:
         SpaceCash: 0
     - type: BuyStoreBank
+      emagCategories:
+        - DrinkVendInventoryEmag
     - type: ActivatableUI
       key: enum.StoreUiKey.Key
       singleUser: true
@@ -127,6 +129,8 @@
       balance:
         SpaceCash: 0
     - type: BuyStoreBank
+      emagCategories:
+        - DrinkVendInventoryEmag
     - type: ActivatableUI
       key: enum.StoreUiKey.Key
       singleUser: true
@@ -149,6 +153,8 @@
       balance:
         SpaceCash: 0
     - type: BuyStoreBank
+      emagCategories:
+        - DrinkVendInventoryEmag
     - type: ActivatableUI
       key: enum.StoreUiKey.Key
       singleUser: true
@@ -369,6 +375,8 @@
       balance:
         SpaceCash: 0
     - type: BuyStoreBank
+      emagCategories:
+        - DrinkVendInventoryEmag
     - type: ActivatableUI
       key: enum.StoreUiKey.Key
       singleUser: true
@@ -391,6 +399,8 @@
       balance:
         SpaceCash: 0
     - type: BuyStoreBank
+      emagCategories:
+        - DrinkVendInventoryEmag
     - type: ActivatableUI
       key: enum.StoreUiKey.Key
       singleUser: true
@@ -413,6 +423,8 @@
       balance:
         SpaceCash: 0
     - type: BuyStoreBank
+      emagCategories:
+        - DrinkVendInventoryEmag
     - type: ActivatableUI
       key: enum.StoreUiKey.Key
       singleUser: true
@@ -435,6 +447,8 @@
       balance:
         SpaceCash: 0
     - type: BuyStoreBank
+      emagCategories:
+        - DrinkVendInventoryEmag
     - type: ActivatableUI
       key: enum.StoreUiKey.Key
       singleUser: true
@@ -457,6 +471,8 @@
       balance:
         SpaceCash: 0
     - type: BuyStoreBank
+      emagCategories:
+        - DrinkVendInventoryEmag
     - type: ActivatableUI
       key: enum.StoreUiKey.Key
       singleUser: true
@@ -479,6 +495,8 @@
       balance:
         SpaceCash: 0
     - type: BuyStoreBank
+      emagCategories:
+        - DrinkVendInventoryEmag
     - type: ActivatableUI
       key: enum.StoreUiKey.Key
       singleUser: true
@@ -501,6 +519,8 @@
       balance:
         SpaceCash: 0
     - type: BuyStoreBank
+      emagCategories:
+        - HappyHonkInventoryEmag
     - type: ActivatableUI
       key: enum.StoreUiKey.Key
       singleUser: true

--- a/Resources/Prototypes/Backmen/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Backmen/Entities/Structures/Machines/vending_machines.yml
@@ -83,6 +83,8 @@
       balance:
         SpaceCash: 0
     - type: BuyStoreBank
+      emagCategories:
+        - CigaretteMachineInventoryEmag
     - type: ActivatableUI
       key: enum.StoreUiKey.Key
       singleUser: true
@@ -221,6 +223,8 @@
       balance:
         SpaceCash: 0
     - type: BuyStoreBank
+      emagCategories:
+        - HotDrinksMachineInventoryEmag
     - type: ActivatableUI
       key: enum.StoreUiKey.Key
       singleUser: true

--- a/Resources/Prototypes/Backmen/Store/categories.yml
+++ b/Resources/Prototypes/Backmen/Store/categories.yml
@@ -93,3 +93,11 @@
 - type: storeCategory
   id: HappyHonkInventoryEmag
   name: store-category-emag
+
+- type: storeCategory
+  id: CigaretteMachineInventoryEmag
+  name: store-category-emag
+
+- type: storeCategory
+  id: HotDrinksMachineInventoryEmag
+  name: store-category-emag

--- a/Resources/Prototypes/Backmen/Store/categories.yml
+++ b/Resources/Prototypes/Backmen/Store/categories.yml
@@ -12,11 +12,11 @@
 
 - type: storeCategory
   id: HotDrinksMachineInventory
-  name: store-category-vendingcoffee
+  name: store-category-vending-drinks
 
 - type: storeCategory
   id: RobustSoftdrinksInventory
-  name: store-category-vendingcola
+  name: store-category-vending-drinks
 
 - type: storeCategory
   id: DiscountDansInventory
@@ -36,7 +36,7 @@
 
 - type: storeCategory
   id: BodaInventory
-  name: store-category-vendingsovietsoda
+  name: store-category-vending-drinks
 
 - type: storeCategory
   id: VendingYouTool
@@ -48,35 +48,35 @@
   
 - type: storeCategory
   id: VendingLootboxInventoryEmag
-  name: store-category-lootbox-emag
+  name: store-category-emag
 
 - type: storeCategory
   id: SpaceUpInventory
-  name: store-category-vendingspaceup
+  name: store-category-vending-drinks
 
 - type: storeCategory
   id: ColaRedInventory
-  name: store-category-vendingcolared
+  name: store-category-vending-drinks
 
 - type: storeCategory
   id: ShamblersJuiceInventory
-  name: store-category-vendingshamblersjuice
+  name: store-category-vending-drinks
 
 - type: storeCategory
   id: PwrGameInventory
-  name: store-category-vendingmachinepwrgame
+  name: store-category-vending-drinks
 
 - type: storeCategory
   id: DrGibbInventory
-  name: store-category-vendingmachinedrgibb
+  name: store-category-vending-drinks
 
 - type: storeCategory
   id: StarkistInventory
-  name: store-category-vendingmachinestarkist
+  name: store-category-vending-drinks
 
 - type: storeCategory
   id: HappyHonkInventory
-  name: store-category-vendingmachineHappyHonk
+  name: store-category-HappyHonk
 
 - type: storeCategory
   id: BoxingDrobeInventory
@@ -84,4 +84,12 @@
   
 - type: storeCategory
   id: BoxingDrobeInventoryEmag
-  name: store-category-vendingmachineboxingdrobe-emag
+  name: store-category-emag
+
+- type: storeCategory
+  id: DrinkVendInventoryEmag
+  name: store-category-emag
+
+- type: storeCategory
+  id: HappyHonkInventoryEmag
+  name: store-category-emag


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Данный ПР добавляет автоматам с напитками, сигаретами, кофе и Хэппи Хонкам свои собственные емаг стейты!
Микробонус: у автомата ЛутБоксы теперь адекватное описание

Автоматы с напитками:
- 2 Нюки Робаст
- 2 Жала Генокрада

Автомат с кофе:
- 2 Ничего

Автомат с сигаретами:
- 1 пачка трав Интердайн

Автомат Хэппи Хонк:
- 1 обед Нюка Робаст (только игрушка)
- 1 обед Жалкий Клувень

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят.

В журнал изменений следует помещать только то, что действительно важно игрокам.

В списке изменений тип значка не является часть предложения, поэтому явно указывайте - Добавлен, Удалён, Изменён.
плохо: - add: Новый инструмент для инженеров
хорошо: - add: Добавлен новый инструмент для инженеров

Вы можете указать своё имя после символа :cl: именно оно будет отображаться в журнале изменений (иначе будет использоваться ваше имя на GitHub)
Например: :cl: Ian

-->

:cl: Rouden
- fix: Большинство торгоматов снова можно взламывать с помощью криптографического секвенсора, что открывает новую категорию для покупок контрабандных предметов.
