### PR TITLE
Fix Memetic Amirmir disease

### DIFF
--- a/Resources/Prototypes/Backmen/Diseases/infectious.yml
+++ b/Resources/Prototypes/Backmen/Diseases/infectious.yml
@@ -235,11 +235,12 @@
   - !type:DiseaseReagentCure
     reagent:
       ReagentId: Coffee
-    min: 35
+    min: 10
   - !type:DiseaseReagentCure
     reagent:
       ReagentId: IrishCoffee
-    min: 10
+  - !type:DiseaseJustWaitCure
+    maxLength: 900
 
 - type: disease
   id: BleedersBite


### PR DESCRIPTION
## Описание PR
Микрофикс болезни Меметик Амирир, теперь для лечения нужно либо выпить кружку-две кофе, либо сделать глоток ирландского кофе, либо подождать 900 секунд. С числами которые использовались ранее, вылечить эту болезнь было несправедливо тяжело.

:cl: Rouden
- fix: Болезнь Меметик Амирир теперь гораздо проще вылечить.