### PR TITLE
Remove CentcommV2

### DIFF
--- a/Resources/Prototypes/_Backmen/centcom_maps.yml
+++ b/Resources/Prototypes/_Backmen/centcom_maps.yml
@@ -3,5 +3,5 @@
   id: DefaultCentcomPool
   weights:
     CentComm: 0.5
-    CentCommv2: 0.35
+#    CentCommv2: 0.35
 #    CentCommv3: 0.7


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Убирает корваксовский центкомм за ненадобностью, поскольку на нём нету света, и ЦК более не является игровой зоной.

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.