### PR TITLE
Buff Superstimulants

### DIFF
--- a/Resources/Prototypes/_Backmen/Reagents/narcotics.yml
+++ b/Resources/Prototypes/_Backmen/Reagents/narcotics.yml
@@ -11,7 +11,7 @@
   meltingPoint: 170.0
   metabolisms:
     Narcotic:
-      metabolismRate: 0.5
+      metabolismRate: 1
       effects:
       - !type:MovespeedModifier # This is frickin' fast
         walkSpeedModifier: 1.5
@@ -19,10 +19,10 @@
       - !type:HealthChange
         conditions:
           - !type:ReagentThreshold
-            min: 16
+            min: 30
         damage: # If you get robust too much, you can go to hell!
           types:
-            Poison: 4
+            Poison: 3
       - !type:GenericStatusEffect
           key: Stutter
           component: StutteringAccent
@@ -46,14 +46,14 @@
         type: Local
         probability: 0.10
     Medicine:
-      metabolismRate: 0.5
+      metabolismRate: 1
       effects:
         - !type:ResetNarcolepsy
         - !type:SatiateHunger
           factor: 1.0
         - !type:SatiateThirst
           factor: 1.0
-        - !type:ModifyBleedAmount # Tranexamic acid in recipe, so it's also stops bleeding, but not that efficient
+        - !type:ModifyBleedAmount
           amount: -1
         - !type:HealthChange
           damage:


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Передоз у суперстимулятора теперь не такой сильный как прежде, а скорость метаболизма возвращена к уровню гиперзина.

Пониженный передоз позволит более активно использовать суперстимуляторы, что сделает их более полезными, и возможно их будут использовать чаще чем никогда :cat_of_reaction:

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
:cl: Rouden
- tweak: Суперстимуляторы теперь имеют не такую сильную передозировку как раньше.