### PR TITLE
Add Blob, Flech cult and Vampires in AlltOnce preset

### DIFF
--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -24,6 +24,9 @@
     - RampingStationEventScheduler
     - WageScheduler #backmen: currency
     - GameRuleMeteorScheduler
+    - BlobGameMode # backmen: blob
+    - VampiresGameRule # backmen: vampire
+    - FleshCult # backmen: flesh cult
 
 - type: gamePreset
   id: Extended


### PR DESCRIPTION
## Описание PR
Блоб, культ плоти и вампиры были добавлены в режим Всё И Сразу.
Антагов больше, играть интереснее

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: Rouden
- fix: Теперь во всё и сразу идут все режимы, эксклюзивные для сборки Backmen.
