### PR TITLE
fix кошака, неправильный обозначение

### DIFF
--- a/Resources/Locale/ru-RU/items/components/item-component.ftl
+++ b/Resources/Locale/ru-RU/items/components/item-component.ftl
@@ -15,7 +15,7 @@ item-component-size-Ginormous = гигантский
 
 
 # backmen
-pseudoitem-contained = Вы можете это запихнуть в сумку!
-pseudoitem-not-contained = Кто-то запихал это в сумку!
+pseudoitem-contained = Кто-то запихал это в сумку!
+pseudoitem-not-contained = Вы можете это запихнуть в сумку!
 item-component-size-Felinid = кошка?!
 item-component-size-HeavyMachineGun = тяжелое вооружение


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Почему-то неправильно написано у кошака описание вне мешка и в мешке. Будто кто-то перепутал.
Перепутана:
> **pseudoitem-contained = Вы можете это запихнуть в сумку!**
**pseudoitem-not-contained =  Кто-то запихал это в сумку!**

Когда должно быть наоборот:
> **pseudoitem-contained = Кто-то запихал это в сумку!**
**pseudoitem-not-contained =  Вы можете это запихнуть в сумку!**

**Медиа**
Вот как пример было неправильного.
**В мешке:**
![5523](https://github.com/user-attachments/assets/b08f09f5-aae7-4460-b13d-f30369e574eb)
**Не в мешке:**
![sdasdsa](https://github.com/user-attachments/assets/c9fb7f4b-bf64-4cb9-a096-e09918243605)


**Проверки**

- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.

:cl:
- fix: правильное отображение кошака в мешке и без мешка.