### PR TITLE
Fix Thief comms bundle + salvage cash types

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/briefcases.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/briefcases.yml
@@ -55,7 +55,7 @@
   - type: StorageFill
     contents:
       - id: ClothingEyesGlassesSunglasses
-      - id: CargoCash20000
+      - id: SpaceCash2500
         amount: 1
       - id: ClothingOuterCoatJensen
       - id: ClothingHandsGlovesColorBlack

--- a/Resources/Prototypes/Procedural/salvage_loot.yml
+++ b/Resources/Prototypes/Procedural/salvage_loot.yml
@@ -88,12 +88,12 @@
         - proto: RipleyHarness
           cost: 3
           prob: 0.5
-        - proto: SpaceCash1000
-        - proto: SpaceCash10000
+        - proto: CargoCash1000
+        - proto: CargoCash10000
           cost: 10
-        - proto: SpaceCash2500
+        - proto: CargoCash2500
           cost: 3
-        - proto: SpaceCash5000
+        - proto: CargoCash5000
           cost: 5
         - proto: TechnologyDiskRare
           cost: 5

--- a/Resources/Prototypes/_Backmen/Entities/Objects/Misc/cargo_cash.yml
+++ b/Resources/Prototypes/_Backmen/Entities/Objects/Misc/cargo_cash.yml
@@ -61,6 +61,28 @@
 
 - type: entity
   parent: CargoCash
+  id: CargoCash1000
+  suffix: 1000
+  components:
+  - type: Icon
+    sprite: Objects/Economy/cash.rsi
+    state: cash_1000
+  - type: Stack
+    count: 1000
+
+- type: entity
+  parent: CargoCash
+  id: CargoCash2500
+  suffix: 2500
+  components:
+  - type: Icon
+    sprite: Objects/Economy/cash.rsi
+    state: cash_1000
+  - type: Stack
+    count: 2500
+
+- type: entity
+  parent: CargoCash
   id: CargoCash5000
   suffix: 5000
   components:
@@ -72,14 +94,14 @@
 
 - type: entity
   parent: CargoCash
-  id: CargoCash30000
-  suffix: 30000
+  id: CargoCash10000
+  suffix: 10000
   components:
   - type: Icon
     sprite: Objects/Economy/cash.rsi
     state: cash_1000
   - type: Stack
-    count: 30000
+    count: 10000
 
 - type: entity
   parent: CargoCash
@@ -91,3 +113,14 @@
     state: cash_1000
   - type: Stack
     count: 20000
+
+- type: entity
+  parent: CargoCash
+  id: CargoCash30000
+  suffix: 30000
+  components:
+  - type: Icon
+    sprite: Objects/Economy/cash.rsi
+    state: cash_1000
+  - type: Stack
+    count: 30000


### PR DESCRIPTION
## Описание PR
- У вора вместо 20к векселей теперь 2.5к обычных кредитов
- На экспедициях теперь можно найти только векселя

## Зачем
С помощью кредитов вор может подкупать людей для выполнения своих целей, что даёт много поводов для взаимодействий и РП.
А на экспах вообще не должно быть кредитов чисто из баланса, поскольку это бесконечный источник кредитов для абуза лутбоксов

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят.

В журнал изменений следует помещать только то, что действительно важно игрокам.

В списке изменений тип значка не является часть предложения, поэтому явно указывайте - Добавлен, Удалён, Изменён.
плохо: - add: Новый инструмент для инженеров
хорошо: - add: Добавлен новый инструмент для инженеров

Вы можете указать своё имя после символа :cl: именно оно будет отображаться в журнале изменений (иначе будет использоваться ваше имя на GitHub)
Например: :cl: Ian

-->

:cl: Rouden
- tweak: Теперь у вора в чемодане из набора коммуникаций лежат космокредиты вместо векселей.
- fix: На экспедициях можно найти только вексели вместо космокредитов.
