### PR TITLE
Remove station goal

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/fax_machine.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/fax_machine.yml
@@ -83,7 +83,7 @@
   - type: FaxMachine
     name: "Central Command"
     notifyAdmins: true
-    receiveStationGoal: true # Corvax-StationGoal
+    #receiveStationGoal: true # Corvax-StationGoal
 
 - type: entity
   parent: FaxMachineBase
@@ -111,6 +111,6 @@
     - type: FaxMachine
       name: "Captain's Office"
       receiveNukeCodes: true
-      receiveStationGoal: true # Corvax-StationGoal
+      #receiveStationGoal: true # Corvax-StationGoal
     - type: StealTarget
       stealGroup: FaxMachineCaptain


### PR DESCRIPTION
## Описание PR
Согласно двум опросникам в ДС а также нашей новой политике, цель станции лишь создаёт духоту и на неё и так все забивают, потому цели станций должны быть отключены.
