### PR TITLE
[Fix] Remove Telescope From Rifles

### DIFF
--- a/Resources/Prototypes/_Backmen/Entities/Objects/Weapons/Guns/guns64super.yml
+++ b/Resources/Prototypes/_Backmen/Entities/Objects/Weapons/Guns/guns64super.yml
@@ -27,7 +27,6 @@
         volume: -2
   - type: UseDelay
     delay: 0.7
-  - type: Telescope # Ataraxia
 
 - type: entity
   name: M-28 Tactical
@@ -63,7 +62,6 @@
     mask: /Textures/Effects/LightMasks/cone.png
     autoRot: true
     radius: 8
-  - type: Telescope # Ataraxia
 
 - type: entity
   name: G-36 Tactical
@@ -131,7 +129,6 @@
     angleIncrease: -7
   - type: UseDelay
     delay: 0.2
-  - type: Telescope # Ataraxia
 
 - type: entity
   name: MP5 Tactical
@@ -167,7 +164,6 @@
     radius: 8
   - type: UseDelay
     delay: 0.2
-  - type: Telescope # Ataraxia
 
 - type: entity
   name: XM1014 Tactical
@@ -196,7 +192,6 @@
     mask: /Textures/Effects/LightMasks/cone.png
     autoRot: true
     radius: 8
-  - type: Telescope # Ataraxia
 
 - type: entity
   name: AK74-U Tactical
@@ -229,7 +224,6 @@
         volume: -3
   - type: UseDelay
     delay: 0.1
-  - type: Telescope # Ataraxia
 
 - type: entity
   name: P-90 Tactical
@@ -261,7 +255,6 @@
         volume: -3
   - type: UseDelay
     delay: 0.1
-  - type: Telescope # Ataraxia
 
 - type: entity
   name: RPD Tactical


### PR DESCRIPTION
# Описание PR
Удалён компонент `telescope` у всех моделей автомата Калашникова.  
Ранее при выстреле камера могла отдаляться настолько сильно, что можно было заметить грустного разработчика этого кода.

## Тип PR
- [x] Fix

**Изменения**
- remove: Удалён компонент `telescope` у всех автоматов Калашникова.
- fix: Исправлена отдача при стрельбе из автоматов Калашникова.