### PR TITLE
[Tweak] Disable Spacewind

### DIFF
--- a/Resources/ConfigPresets/Backmen/main.toml
+++ b/Resources/ConfigPresets/Backmen/main.toml
@@ -62,7 +62,7 @@ enabled_crit = true
 easy_mode = false
 
 [atmos]
-space_wind = true
+space_wind = false
 space_wind_max_velocity = 22.0
 #tickrate = 7
 monstermos_rip_tiles = true


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR
Данный ПР отключает космоветер.
Он является одним из подозреваемых в сильных лагах из-за PhysicsSystem, поэтому для баланса сервера будет правильнее отключить его.

## Тип PR
<!-- Подходите ответственно к пометке этих пунктов, для этого необходимо поставить английскую "x" между квадратных скобок -->
- [X] Feature
- [ ] Fix
- [ ] Tweak
- [ ] Balance
- [ ] Refactor
- [ ] Port
- [ ] Translate
- [ ] Resprite