### PR TITLE
[FIX] Некоторые роли не получают аварийные наборы

### DIFF
--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -152,6 +152,7 @@
   - CommonBackpack
   - Glasses
   - Medals #backmen
+  - Survival
   - Inventory # Corvax-Loadouts
   - Trinkets
   - GroupSpeciesBreathTool
@@ -520,6 +521,7 @@
   - SecurityPocket #Backmen
   - SecurityPocket2 #Backmen
   - Medals #backmen
+  - SurvivalSecurity
   - Trinkets
   - SecurityStar
   - GroupSpeciesBreathToolSecurity
@@ -555,6 +557,7 @@
   - SecurityCadetJumpsuit
   - SecurityBackpack
   - Medals #backmen
+  - SurvivalSecurity
   - Trinkets
   - GroupSpeciesBreathToolSecurity
 
@@ -671,6 +674,7 @@
   - CommonBackpack
   - Glasses
   - Medals #backmen
+  - Survival
   - Trinkets
   - GroupSpeciesBreathTool
 


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR
<!-- Опишите здесь ваш Pull Request (PR). Что он изменяет? На что еще это может повлиять? -->
Некоторые роли **ПОЧЕМУ-ТО** не получали свои аварийные наборы. Активны NT упали? Нет, боги нашалили. Мне лень искать что пошло не так в прошлом, но сейчас всё работает.

<!-- Место для вашего чек-листа, здесь можно составить список, к примеру того, что вы хотите сделать.
## Чек-лист

- [x] Я сделаю хорошее
-->

## Тип PR
<!-- Подходите ответственно к пометке этих пунктов, для этого необходимо поставить английскую "x" между квадратных скобок -->
- [ ] Feature
- [X] Fix
- [ ] Tweak
- [ ] Balance
- [ ] Refactor
- [ ] Port
- [ ] Translate
- [ ] Resprite

**Изменения**
<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят
Для записей в списке изменений есть 4 значка: add, remove, tweak, fix. Думаю, вы сможете разобраться с остальным.

Вы можете поставить свой ник после символа :cl:, чтобы изменить ник, который будет отображаться в журнале изменений (в противном случае будет использоваться ник вашего аккаунта GitHub)
Например: ":cl: PuroSlavKing".

Как правило, в журналы изменений следует помещать только то, что действительно важно игрокам. Вещи вроде "Рефактор системы X, но изменений вы не увидите" - не должны быть в журнале изменений, эти изменения обычные игроки не смогут заметить.

При написании списка изменений НЕ считайте суффикс типа записи (например, add) "частью" предложения:
Плохо: - add: Хирургия может вырезать яйца.
Хорошо: - add: Добавлена хирургическая операция, которая позволяет вырезать яйца.
-->
:cl: Sodka
- fix: Теперь у следующих ролей: агент внутренних дел, офицер службы безопасности, кадет службы безопасности и зоолог имеются аварийные наборы.