### PR TITLE
[BALANCE] Barrier in the elite spacesuit has been removed.

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -586,29 +586,6 @@
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndieElite
-  - type: ContainerContainer #backmen-shield-start
-    containers:
-      cell_slot: !type:ContainerSlot
-      toggleable-clothing: !type:ContainerSlot
-  - type: PowerCellSlot
-    cellSlotId: cell_slot
-  - type: ItemSlots
-    slots:
-      cell_slot:
-        name: power-cell-slot-component-slot-name-default
-        startingItem: PowerCellHyper
-        whitelist:
-          tags:
-            - PowerCell
-            - PowerCellSmall
-  - type: EnergyDomeGenerator
-    damageEnergyDraw: 4
-    domePrototype: EnergyDomeSmallPink
-  - type: PowerCellDraw
-    drawRate: 0
-    useRate: 0
-  - type: UseDelay
-    delay: 10.0 #backmen-shield-end
 
 #Syndicate Commander Hardsuit
 - type: entity


### PR DESCRIPTION
# Описание PR
Практика показала, что наличие двух активных барьеров у соло ЯО полностью нивелирует любое нападение. Ситуация усугубляется тем, что кроме встроенного щита в элитном скафандре, можно дополнительно приобрести пояс со щитом. В результате ЯО получает два щита, которые работают одновременно: как только один истощается, второй сразу же принимает на себя урон. Это приводит к тому, что невозможно пробить оба щита даже за три-четыре обоймы из ПП. Это 90 патронов на секунду.

Необходимо внести изменения: либо пересмотреть механики защиты, либо сделать так, чтобы два щита не могли функционировать одновременно. Я же просто убрал встроенный барьер.

## Тип PR
- [x] Balance

:cl: CrimeMoot
- remove: Встроенный барьер в элитном скафандре убран
