### PR TITLE
[BALANCE] Balance energo shields

### DIFF
--- a/Resources/Prototypes/_Backmen/Catalog/uplink_nomad.yml
+++ b/Resources/Prototypes/_Backmen/Catalog/uplink_nomad.yml
@@ -539,7 +539,7 @@
   description: uplink-energy-dome-desc
   productEntity: EnergyDomeGeneratorPersonalSyndie
   cost:
-    Telecrystal: 30
+    Telecrystal: 10
   categories:
   - UplinkWearables
   conditions:
@@ -558,6 +558,6 @@
   discountDownTo:
     Telecrystal: 1
   cost:
-    Telecrystal: 3
+    Telecrystal: 2
   categories:
   - UplinkPointless

--- a/Resources/Prototypes/_Backmen/Catalog/uplink_nomad.yml
+++ b/Resources/Prototypes/_Backmen/Catalog/uplink_nomad.yml
@@ -538,11 +538,8 @@
   name: uplink-energy-dome-name
   description: uplink-energy-dome-desc
   productEntity: EnergyDomeGeneratorPersonalSyndie
-  discountCategory: usualDiscounts
-  discountDownTo:
-    Telecrystal: 4
   cost:
-    Telecrystal: 6
+    Telecrystal: 30
   categories:
   - UplinkWearables
   conditions:
@@ -561,6 +558,6 @@
   discountDownTo:
     Telecrystal: 1
   cost:
-    Telecrystal: 2
+    Telecrystal: 3
   categories:
   - UplinkPointless

--- a/Resources/Prototypes/_Backmen/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_Backmen/Damage/modifier_sets.yml
@@ -123,6 +123,6 @@
     Blunt: 2.0
     Slash: 2.0
     Piercing: 2.0
-    Cold: 2.0
+    Cold: 0.4
     Shock: 0.4
     Stun: 4.0

--- a/Resources/Prototypes/_Backmen/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_Backmen/Damage/modifier_sets.yml
@@ -119,9 +119,10 @@
 - type: damageModifierSet
   id: HardLightBarrier
   coefficients:
-    Heat: 2.0
-    Blunt: 1.0
-    Slash: 1.0
-    Piercing: 1.0
-    Cold: 1.0
-    Shock: 2.0
+    Heat: 0.4
+    Blunt: 2.0
+    Slash: 2.0
+    Piercing: 2.0
+    Cold: 2.0
+    Shock: 0.4
+    Stun: 4.0

--- a/Resources/Prototypes/_Backmen/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_Backmen/Damage/modifier_sets.yml
@@ -119,9 +119,9 @@
 - type: damageModifierSet
   id: HardLightBarrier
   coefficients:
-    Heat: 0.8
-    Blunt: 0.8
-    Slash: 0.8
-    Piercing: 0.8
-    Cold: 0.8
-    Shock: 1.6
+    Heat: 2.0
+    Blunt: 1.0
+    Slash: 1.0
+    Piercing: 1.0
+    Cold: 1.0
+    Shock: 2.0

--- a/Resources/Prototypes/_Backmen/Entities/Objects/Tools/energydome.yml
+++ b/Resources/Prototypes/_Backmen/Entities/Objects/Tools/energydome.yml
@@ -32,10 +32,10 @@
     damageEnergyDraw: 5
     domePrototype: EnergyDomeSmallRed
   - type: PowerCellDraw
-    drawRate: 0
+    drawRate: 3
     useRate: 0
   - type: UseDelay
-    delay: 10.0
+    delay: 15.0
 
 - type: entity
   name: BR-40c "Turtle"
@@ -84,10 +84,10 @@
     domePrototype: EnergyDomeMediumBlue
     canDeviceNetworkUse: true
   - type: PowerCellDraw
-    drawRate: 0
+    drawRate: 3
     useRate: 0
   - type: UseDelay
-    delay: 10.0
+    delay: 15.0
   - type: DeviceNetwork
     deviceNetId: Wireless
     receiveFrequencyId: BasicDevice
@@ -212,10 +212,10 @@
     damageEnergyDraw: 5
     domePrototype: EnergyDomeMediumRed
   - type: PowerCellDraw
-    drawRate: 0
+    drawRate: 3
     useRate: 0
   - type: UseDelay
-    delay: 10.0
+    delay: 15.0
 
 - type: entity
   name: BT-21b "Barrier"
@@ -251,7 +251,7 @@
     damageEnergyDraw: 5
     domePrototype: EnergyDomeSmallBlue
   - type: PowerCellDraw
-    drawRate: 0
+    drawRate: 3
     useRate: 0
   - type: UseDelay
-    delay: 10.0
+    delay: 15.0

--- a/Resources/Prototypes/_Backmen/Entities/Objects/Tools/energydome.yml
+++ b/Resources/Prototypes/_Backmen/Entities/Objects/Tools/energydome.yml
@@ -29,7 +29,7 @@
             - PowerCell
             - PowerCellSmall
   - type: EnergyDomeGenerator
-    damageEnergyDraw: 5
+    damageEnergyDraw: 7
     domePrototype: EnergyDomeSmallRed
   - type: PowerCellDraw
     drawRate: 3
@@ -80,7 +80,7 @@
             - PowerCell
             - PowerCellSmall
   - type: EnergyDomeGenerator
-    damageEnergyDraw: 5
+    damageEnergyDraw: 7
     domePrototype: EnergyDomeMediumBlue
     canDeviceNetworkUse: true
   - type: PowerCellDraw
@@ -209,7 +209,7 @@
             - PowerCell
             - PowerCellSmall
   - type: EnergyDomeGenerator
-    damageEnergyDraw: 5
+    damageEnergyDraw: 7
     domePrototype: EnergyDomeMediumRed
   - type: PowerCellDraw
     drawRate: 3
@@ -248,7 +248,7 @@
             - PowerCell
             - PowerCellSmall
   - type: EnergyDomeGenerator
-    damageEnergyDraw: 5
+    damageEnergyDraw: 7
     domePrototype: EnergyDomeSmallBlue
   - type: PowerCellDraw
     drawRate: 3


### PR DESCRIPTION
# Описание PR
Балансировка существующих щитов в игре. 

- [x] Balance

:cl: CrimeMoot
- add: Теперь в поясе энергетического щита в аплинке встроена обычная батарейка.
- remove: Удалены сверхбольшие встроенные батарейки в поясе энергетического щита с аплинка.
- remove: Энергетический щит убран раздел со скидкой (Не ясно зачем оно, если купить могут только ЯО, а скидки только на агентов работают)
- tweak: Теперь все щиты получают повышенный урон от пуль, в два раза. Однако, теперь они получают на 70% меньше урона от источников: Шок и Термический урон. Станнеры наносят урон в 5 раз больше.
- tweak: Теперь активный щит пассивно тратит 3 единицы энергии.
- tweak: После отключения щита, его можно будет включить только через 15 секунд, ранее было 10.
- tweak: Щит от повреждений быстрее разряжается. Раньше он тратил 5 зарядов за попадание, теперь 7.
- tweak: Щит теперь стоит не 6 ТК, а 10.