### PR TITLE
[Tweak] Body doll in Health Analyzer menu

### DIFF
--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml.cs
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml.cs
@@ -4,6 +4,7 @@ using Content.Client.Message;
 using Content.Shared.Atmos;
 using Content.Client.UserInterface.Controls;
 using Content.Shared.Alert;
+using Content.Shared.Backmen.Targeting;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.FixedPoint;
@@ -35,6 +36,8 @@ namespace Content.Client.HealthAnalyzer.UI
         private readonly SpriteSystem _spriteSystem;
         private readonly IPrototypeManager _prototypes;
         private readonly IResourceCache _cache;
+
+        private EntityUid _spriteViewEntity; // backmen: surgery
 
         public HealthAnalyzerWindow()
         {
@@ -71,8 +74,7 @@ namespace Content.Client.HealthAnalyzer.UI
             ScanModeLabel.FontColorOverride = msg.ScanMode.HasValue && msg.ScanMode.Value ? Color.Green : Color.Red;
 
             // Patient Information
-
-            SpriteView.SetEntity(target.Value);
+            SpriteView.SetEntity(SetupIcon(msg.Body) ?? target.Value); // backmen: surgery
             SpriteView.Visible = msg.ScanMode.HasValue && msg.ScanMode.Value;
             NoDataTex.Visible = !SpriteView.Visible;
 
@@ -243,5 +245,46 @@ namespace Content.Client.HealthAnalyzer.UI
 
             return rootContainer;
         }
+
+        [ValidatePrototypeId<EntityPrototype>]
+        private readonly EntProtoId _bodyView = "AlertSpriteView";
+
+        // start-backmen: surgery
+        /// <summary>
+        /// Sets up the Body Doll using Alert Entity to use in Health Analyzer.
+        /// </summary>
+        private EntityUid? SetupIcon(Dictionary<TargetBodyPart, TargetIntegrity>? body)
+        {
+            if (body is null)
+                return null;
+
+            if (!_entityManager.Deleted(_spriteViewEntity))
+                _entityManager.QueueDeleteEntity(_spriteViewEntity);
+
+            _spriteViewEntity = _entityManager.Spawn(_bodyView);
+            if (!_entityManager.TryGetComponent<SpriteComponent>(_spriteViewEntity, out var sprite))
+                return null;
+
+            int layer = 0;
+            foreach (var (bodyPart, integrity) in body)
+            {
+                // TODO: Fix this way PartStatusUIController and make it use layers instead of TextureRects
+                string enumName = Enum.GetName(typeof(TargetBodyPart), bodyPart) ?? "Unknown";
+                int enumValue = (int) integrity;
+                var rsi = new SpriteSpecifier.Rsi(new ResPath($"/Textures/Interface/Targeting/Status/{enumName.ToLowerInvariant()}.rsi"), $"{enumName.ToLowerInvariant()}_{enumValue}");
+                // It's probably shitcode but im lazy to get into sprite stuff
+                if (!sprite.TryGetLayer(layer, out _))
+                    sprite.AddLayer(_spriteSystem.Frame0(rsi));
+                else
+                    sprite.LayerSetTexture(layer, _spriteSystem.Frame0(rsi));
+
+                layer++;
+            }
+
+            _entityManager.Dirty(_spriteViewEntity, sprite);
+            return _spriteViewEntity;
+        }
+
+        // end-backmen: surgery
     }
 }

--- a/Content.Server/Medical/CryoPodSystem.cs
+++ b/Content.Server/Medical/CryoPodSystem.cs
@@ -202,6 +202,7 @@ public sealed partial class CryoPodSystem : SharedCryoPodSystem
                 : 0,
             null,
             null,
+            null,
             null
         ));
     }

--- a/Content.Server/Medical/HealthAnalyzerSystem.cs
+++ b/Content.Server/Medical/HealthAnalyzerSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Medical.Components;
 using Content.Server.PowerCell;
 using Content.Server.Temperature.Components;
 using Content.Server.Traits.Assorted;
+using Content.Shared.Backmen.Targeting;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Damage;
 using Content.Shared.DoAfter;
@@ -210,13 +211,20 @@ public sealed class HealthAnalyzerSystem : EntitySystem
         if (HasComp<UnrevivableComponent>(target))
             unrevivable = true;
 
+        // start-backmen: surgery
+        Dictionary<TargetBodyPart, TargetIntegrity>? body = null;
+        if (TryComp<TargetingComponent>(target, out var targetingComponent))
+            body = targetingComponent.BodyStatus;
+        // end-backmen: surgery
+
         _uiSystem.ServerSendUiMessage(healthAnalyzer, HealthAnalyzerUiKey.Key, new HealthAnalyzerScannedUserMessage(
             GetNetEntity(target),
             bodyTemperature,
             bloodAmount,
             scanMode,
             bleeding,
-            unrevivable
+            unrevivable,
+            body // backmen: surgery
         ));
     }
 }

--- a/Content.Shared/MedicalScanner/HealthAnalyzerScannedUserMessage.cs
+++ b/Content.Shared/MedicalScanner/HealthAnalyzerScannedUserMessage.cs
@@ -1,3 +1,5 @@
+using Content.Shared.Backmen.Targeting;
+using Content.Shared.Body.Components;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.MedicalScanner;
@@ -14,8 +16,9 @@ public sealed class HealthAnalyzerScannedUserMessage : BoundUserInterfaceMessage
     public bool? ScanMode;
     public bool? Bleeding;
     public bool? Unrevivable;
+    public Dictionary<TargetBodyPart, TargetIntegrity>? Body; // backmen: surgery
 
-    public HealthAnalyzerScannedUserMessage(NetEntity? targetEntity, float temperature, float bloodLevel, bool? scanMode, bool? bleeding, bool? unrevivable)
+    public HealthAnalyzerScannedUserMessage(NetEntity? targetEntity, float temperature, float bloodLevel, bool? scanMode, bool? bleeding, bool? unrevivable, Dictionary<TargetBodyPart, TargetIntegrity>? body)
     {
         TargetEntity = targetEntity;
         Temperature = temperature;
@@ -23,6 +26,7 @@ public sealed class HealthAnalyzerScannedUserMessage : BoundUserInterfaceMessage
         ScanMode = scanMode;
         Bleeding = bleeding;
         Unrevivable = unrevivable;
+        Body = body; // backmen: surgery
     }
 }
 


### PR DESCRIPTION
[RU]
- В меню анализатора здоровья добавлена Кукла, которая примерно отображает нанесённый по разным частям тела урон!

[EN]
- You can now see the Body doll and aproximate damage of all body parts in Health Analyzer!

## Media
https://github.com/user-attachments/assets/273c4322-947d-4b71-a863-e9bbbe545545

## Technical details
I think it's actually pretty shitcodey in the sprite drawing part, but it's working completly fine on client.
fxes **partially** #873

~~Related to https://github.com/Simple-Station/Einstein-Engines/pull/1159~~ no it's not, EE doesn't have Wizden Health Analyzer UI apparently