### PR TITLE
фикс супер пси

### DIFF
--- a/Content.Server/Backmen/Antag/SuperPsi/AutoPsiSystem.cs
+++ b/Content.Server/Backmen/Antag/SuperPsi/AutoPsiSystem.cs
@@ -141,7 +141,7 @@ public sealed class AutoPsiSystem : EntitySystem
 #if DEBUG
                 1f
 #else
-               0.2f
+               0.35f
 #endif
             )
 #if !DEBUG

--- a/Resources/Prototypes/_Backmen/Roles/Antags/superpsi.yml
+++ b/Resources/Prototypes/_Backmen/Roles/Antags/superpsi.yml
@@ -34,6 +34,8 @@
       lateJoinAdditional: false
       briefing:
         sound: "/Audio/Misc/thief_greeting.ogg"
+      mindRoles:
+      - MindRoleSuperPsi
 
 - type: entity
   id: SpawnerUristMcNars


### PR DESCRIPTION
:cl: 
- tweak: Шанс появления супер пси с 20% до 35% (кол-во игроков для появления также и осталось от 20).
- fix: Теперь супер псих получает цели корректно.
