### PR TITLE
[FIX] Cuff popup

### DIFF
--- a/Resources/Prototypes/_Backmen/Entities/Objects/Misc/handcuffs.yml
+++ b/Resources/Prototypes/_Backmen/Entities/Objects/Misc/handcuffs.yml
@@ -16,4 +16,3 @@
   - type: Handcuff
     cuffedRSI: Backmen/Objects/Misc/purplecuff.rsi
     bodyIconState: body-overlay
-    breakoutTime: 5


### PR DESCRIPTION
# Описание PR
https://github.com/Rxup/space-station-14/issues/904 fix отображение текста снятие/одевание наручников

## Медиа
![2024-11-09_05-48-54](https://github.com/user-attachments/assets/d3a2eb52-39e9-4859-94a4-b95c3c45b73f)
![2024-11-09_05-48-49](https://github.com/user-attachments/assets/6ee3b801-cd84-40bc-842b-c8365f279453)
![2024-11-09_05-48-44](https://github.com/user-attachments/assets/d0bbacce-ab40-49f3-b2a7-261426b5555a)

## Тип PR
- [x] Fix

:cl: CrimeMoot
- fix: Исправлена ошибка с неотображением Popup на мягких наручниках.
