### PR TITLE
[tweak] Disease protection and quality of life additionals.

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -10,8 +10,9 @@
     - id: ClothingMaskBreath
     - id: EmergencyOxygenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen
     - id: Flare
-    - id: FoodSnackNutribrick
+    - id: FoodTinMRE
     - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -28,8 +29,9 @@
     - id: ClothingMaskBreath
     - id: EmergencyNitrogenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen
     - id: Flare
-    - id: FoodSnackNutribrick
+    - id: FoodTinMRE
     - id: DrinkWaterBottleFull
   # Intentionally wrong picture on the box. NT did not care enough to change it.
   - type: Label
@@ -47,8 +49,9 @@
     - id: ClothingMaskBreath
     - id: ExtendedEmergencyOxygenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen
     - id: Flare
-    - id: FoodSnackNutribrick
+    - id: FoodTinMRE
     - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -65,8 +68,9 @@
     - id: ClothingMaskBreath
     - id: ExtendedEmergencyNitrogenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen
     - id: Flare
-    - id: FoodSnackNutribrick
+    - id: FoodTinMRE
     - id: DrinkWaterBottleFull
   # Intentionally wrong picture on the box. NT did not care enough to change it.
   - type: Label
@@ -85,8 +89,9 @@
     - id: ClothingMaskGasSecurity
     - id: EmergencyOxygenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen
     - id: Flare
-    - id: FoodSnackNutribrick
+    - id: FoodTinMRE
     - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -103,8 +108,9 @@
     - id: ClothingMaskGasSecurity
     - id: EmergencyNitrogenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen
     - id: Flare
-    - id: FoodSnackNutribrick
+    - id: FoodTinMRE
     - id: DrinkWaterBottleFull
   # Intentionally wrong picture on the box. NT did not care enough to change it.
   - type: Label
@@ -123,8 +129,9 @@
     - id: ClothingMaskBreathMedical
     - id: EmergencyOxygenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen
     - id: Flare
-    - id: FoodSnackNutribrick
+    - id: FoodTinMRE
     - id: DrinkWaterBottleFull
   - type: Sprite
     layers:
@@ -141,8 +148,9 @@
     - id: ClothingMaskBreathMedical
     - id: EmergencyNitrogenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen
     - id: Flare
-    - id: FoodSnackNutribrick
+    - id: FoodTinMRE
     - id: DrinkWaterBottleFull
   # Intentionally wrong picture on the box. NT did not care enough to change it.
   - type: Label
@@ -170,6 +178,7 @@
     - id: ClothingMaskBreath
     - id: EmergencyFunnyOxygenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen
     - id: Flare
     - id: FoodSnackNutribrick
     - id: DrinkWaterBottleFull
@@ -188,6 +197,7 @@
     - id: ClothingMaskBreath
     - id: EmergencyNitrogenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen
     - id: Flare
     - id: FoodSnackNutribrick
     - id: DrinkWaterBottleFull
@@ -236,8 +246,9 @@
     - id: ClothingMaskGasSyndicate
     - id: ExtendedEmergencyOxygenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen
     - id: Flare
-    - id: FoodSnackNutribrick
+    - id: FoodTinMRE
   - type: Sprite
     layers:
     - state: internals
@@ -253,8 +264,9 @@
     - id: ClothingMaskGasSyndicate
     - id: ExtendedEmergencyNitrogenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen
     - id: Flare
-    - id: FoodSnackNutribrick
+    - id: FoodTinMRE
     # Intentionally wrong picture on the box to mimic the NT one
   - type: Label
     currentLabel: reagent-name-nitrogen

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -5,9 +5,9 @@
   description: A cardboard box for storing things.
   components:
   - type: Item
-    size: Large
+    size: Normal
     shape:
-    - 0,0,2,2
+    - 0,0,1,1
   - type: Storage
     maxItemSize: Small
     grid:

--- a/Resources/Prototypes/Corvax/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Corvax/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -40,3 +40,5 @@
         Shock: 0.1
         Cold: 0.2
         Radiation: 0.2
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2

--- a/Resources/Prototypes/Corvax/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Corvax/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -32,3 +32,5 @@
     damageCoefficient: 0.7
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetCBURNLeader
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.5

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -22,6 +22,8 @@
     - Snout
     - HeadTop
     - HeadSide
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #Atmospherics Hardsuit
 - type: entity
@@ -64,6 +66,8 @@
     coolingCoefficient: 0.005
   - type: FireProtection
     reduction: 0.2
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #Engineering Hardsuit
 - type: entity
@@ -81,6 +85,8 @@
   - type: PressureProtection
     highPressureMultiplier: 0.1
     lowPressureMultiplier: 1000
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #Spationaut Hardsuit
 - type: entity
@@ -117,6 +123,8 @@
   - type: PressureProtection
     highPressureMultiplier: 0.72
     lowPressureMultiplier: 1000
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #Salvage Hardsuit
 - type: entity
@@ -135,6 +143,8 @@
   - type: PointLight
     radius: 7
     energy: 3
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 - type: entity
   parent: ClothingHeadHardsuitBase
@@ -157,6 +167,8 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.9
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #Security Hardsuit
 - type: entity
@@ -181,6 +193,8 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.9
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #Brigmedic Hardsuit
 - type: entity
@@ -207,6 +221,8 @@
   - type: PressureProtection
     highPressureMultiplier: 0.6
     lowPressureMultiplier: 1000
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #Warden's Hardsuit
 - type: entity
@@ -231,6 +247,8 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.9
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #Captain's Hardsuit
 - type: entity
@@ -246,6 +264,8 @@
   - type: PressureProtection
     highPressureMultiplier: 0.3
     lowPressureMultiplier: 1000
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #Chief Engineer's Hardsuit
 - type: entity
@@ -265,6 +285,8 @@
     lowPressureMultiplier: 1000
   - type: FireProtection
     reduction: 0.2
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #Chief Medical Officer's Hardsuit
 - type: entity
@@ -282,6 +304,8 @@
   - type: PressureProtection
     highPressureMultiplier: 0.6
     lowPressureMultiplier: 1000
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #Research Director's Hardsuit
 - type: entity
@@ -299,6 +323,8 @@
   - type: PressureProtection
     highPressureMultiplier: 0.60
     lowPressureMultiplier: 1000
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #Head of Security's hardsuit
 - type: entity
@@ -323,6 +349,8 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.9
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #Luxury Mining Hardsuit
 - type: entity
@@ -341,6 +369,8 @@
   - type: PointLight
     radius: 7
     energy: 3
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #ANTAG HARDSUITS
 #Blood-red Hardsuit
@@ -368,6 +398,8 @@
         Heat: 0.9
   - type: TinfoilHat
     destroyOnFry: false
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #Blood-red Medic Hardsuit
 - type: entity
@@ -394,6 +426,8 @@
         Heat: 0.9
   - type: TinfoilHat
     destroyOnFry: false
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #Syndicate Elite Hardsuit
 - type: entity
@@ -425,6 +459,8 @@
         Heat: 0.9
   - type: TinfoilHat
     destroyOnFry: false
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #Syndicate Commander Hardsuit
 - type: entity
@@ -451,6 +487,8 @@
         Heat: 0.9
   - type: TinfoilHat
     destroyOnFry: false
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #Cybersun Juggernaut Hardsuit
 - type: entity
@@ -477,6 +515,8 @@
         Heat: 0.9
   - type: TinfoilHat
     destroyOnFry: false
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #Wizard Hardsuit
 - type: entity
@@ -502,6 +542,8 @@
         Piercing: 0.9
         Heat: 0.9
   - type: HeadCage
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #Organic Space Suit
 - type: entity
@@ -517,6 +559,8 @@
   - type: PressureProtection
     highPressureMultiplier: 0.225
     lowPressureMultiplier: 1000
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #Pirate EVA Suit (Deep Space EVA Suit)
 - type: entity
@@ -533,6 +577,8 @@
   - type: PressureProtection
     highPressureMultiplier: 0.3
     lowPressureMultiplier: 1000
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #Pirate Captain Hardsuit
 - type: entity
@@ -549,6 +595,8 @@
   - type: PressureProtection
     highPressureMultiplier: 0.3
     lowPressureMultiplier: 1000
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #CENTCOMM / ERT HARDSUITS
 #ERT Leader Hardsuit
@@ -571,6 +619,8 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.9
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #ERT Chaplain Hardsuit
 - type: entity
@@ -585,6 +635,8 @@
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertchaplain.rsi
   - type: PointLight
     color: "#ffffff"
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #ERT Engineer Hardsuit
 - type: entity
@@ -606,6 +658,8 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.9
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #ERT Medical Hardsuit
 - type: entity
@@ -620,6 +674,8 @@
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertmedical.rsi
   - type: PointLight
     color: "#adffec"
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #ERT Security Hardsuit
 - type: entity
@@ -641,6 +697,8 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.9
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #ERT Janitor Hardsuit
 - type: entity
@@ -655,6 +713,8 @@
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertjanitor.rsi
   - type: PointLight
     color: "#cbadff"
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #CBURN Hardsuit
 - type: entity
@@ -694,6 +754,8 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.9
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #Deathsquad Hardsuit
 - type: entity
@@ -723,6 +785,8 @@
         Heat: 0.80
         Radiation: 0.80
         Caustic: 0.95
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #MISC. HARDSUITS
 #Clown Hardsuit
@@ -739,6 +803,8 @@
     sprite: Clothing/Head/Hardsuits/clown.rsi
     equipSound: /Audio/Mecha/mechmove03.ogg
     unequipSound: /Audio/Effects/Emotes/parp1.ogg
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #Mime Hardsuit
 - type: entity
@@ -752,6 +818,8 @@
     sprite: Backmen/Clothing/Head/Hardsuits/mime.rsi
   - type: Clothing
     sprite: Backmen/Clothing/Head/Hardsuits/mime.rsi
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 
 #Santas Hardsuit
 - type: entity
@@ -769,4 +837,6 @@
     color: "#f4ffad"
     radius: 5
     energy: 2
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.2
 

--- a/Resources/Prototypes/Entities/Clothing/Masks/bandanas.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/bandanas.yml
@@ -34,6 +34,8 @@
     slots:
     - Snout
     hideOnToggle: true
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.1
 
 - type: entity
   parent: ClothingMaskBandanaBase

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -19,6 +19,8 @@
     slots:
     - Snout
     hideOnToggle: true
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.1
 
 - type: entity
   parent: [ClothingMaskGas, BaseRestrictedContraband]
@@ -39,6 +41,8 @@
         Slash: 0.95
         Piercing: 0.95
         Heat: 0.95
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.1
 
 - type: entity
   parent: [ClothingMaskGas, BaseSyndicateContraband]
@@ -59,6 +63,8 @@
         Slash: 0.95
         Piercing: 0.95
         Heat: 0.95
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.1
 
 - type: entity
   parent: ClothingMaskGas
@@ -74,6 +80,8 @@
     modifiers:
       coefficients:
         Heat: 0.80
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.1
 
 - type: entity
   parent: [ClothingMaskGasAtmos, BaseCommandContraband]
@@ -87,6 +95,8 @@
     sprite: Clothing/Mask/gascaptain.rsi
   - type: BreathMask
   - type: IngestionBlocker
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.1
 
 - type: entity
   parent: [ ClothingMaskGasAtmos, BaseCentcommContraband ]
@@ -100,6 +110,8 @@
     sprite: Clothing/Mask/gascentcom.rsi
   - type: BreathMask
   - type: IngestionBlocker
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.1
 
 - type: entity
   parent: [ClothingMaskGas, BaseCargoContraband]
@@ -118,6 +130,8 @@
         Slash: 0.90
         Piercing: 0.95
         Heat: 0.95
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.1
 
 - type: entity
   parent: ClothingMaskPullableBase
@@ -137,6 +151,8 @@
     tags:
     - PetWearable
     - WhitelistChameleon
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.1
 
 - type: entity
   parent: ClothingMaskBreathMedical
@@ -157,6 +173,8 @@
         Slash: 0.95
         Piercing: 0.95
         Heat: 0.95
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.1
 
 - type: entity
   parent: ClothingMaskPullableBase
@@ -182,6 +200,8 @@
       Plastic: 100
   - type: StaticPrice
     price: 30 # increases in price after decomposed into raw materials
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.1
 
 - type: entity
   parent: ClothingMaskBase
@@ -302,6 +322,8 @@
   - type: PhysicalComposition
     materialComposition:
       Plastic: 25
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.1
 
 - type: entity
   parent: ClothingMaskBase
@@ -383,6 +405,8 @@
         Slash: 0.90
         Piercing: 0.95
         Heat: 0.95
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.1
 
 - type: entity
   parent: [ ClothingMaskGas, BaseRestrictedContraband ]
@@ -401,6 +425,8 @@
         Slash: 0.90
         Piercing: 0.95
         Heat: 0.95
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.1
 
 - type: entity
   parent: [ ClothingMaskGas, BaseCentcommContraband ]
@@ -429,6 +455,8 @@
         Slash: 0.95
         Piercing: 0.95
         Heat: 0.95
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.1
 
 - type: entity
   parent: ClothingMaskGasERT
@@ -447,6 +475,8 @@
         Slash: 0.80
         Piercing: 0.90
         Heat: 0.90
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.1
 
 - type: entity
   parent: ClothingMaskBase
@@ -579,6 +609,8 @@
   - type: Tag
     tags:
     - WhitelistChameleon
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.1
 
 - type: entity
   parent: ClothingMaskNeckGaiter
@@ -665,3 +697,5 @@
   - type: EyeProtection
   - type: BreathMask
   - type: IdentityBlocker
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.1

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -116,7 +116,7 @@
     sprintModifier: 0.6
   - type: HeldSpeedModifier
   - type: Item
-    size: Ginormous
+    size: Huge
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -146,6 +146,8 @@
       flatReductions:
         Heat: 10 # the average lightbulb only does around four damage!
     slots: OUTERCLOTHING
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.4
 
 - type: entity
   abstract: true
@@ -174,6 +176,8 @@
       flatReductions:
         Heat: 10 # the average lightbulb only does around four damage!
     slots: OUTERCLOTHING
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.3
 
 - type: entity
   parent: ClothingOuterBase

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
@@ -16,6 +16,8 @@
     modifiers:
       coefficients:
         Caustic: 0.5
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.4
 
 - type: entity
   parent: ClothingOuterBioGeneral

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -911,6 +911,8 @@
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitDeathsquad
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 1
 
 #CBURN Hardsuit
 - type: entity
@@ -949,6 +951,8 @@
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetCBURN
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.6
 
 #MISC. HARDSUITS
 #Clown Hardsuit

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
@@ -127,3 +127,5 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+  - type: DiseaseProtection #Backmen & Ataraxia anti viral
+    protection: 0.4


### PR DESCRIPTION
# Описание PR
Я в добровольно-принудительном порядке должен был добавить DiseaseProtectionComponent различным скафандрам, маскам и костюмам биозащиты, что собственно и представлено в данном PR. Однако помимо это я взял и дополнительно внёс несколько "балансных" правок в аварийный набор и в скафандры...

## Тип PR
- [ ] Feature
- [ ] Fix
- [x] Tweak
- [ ] Balance
- [ ] Refactor
- [ ] Port
- [ ] Translate
- [ ] Resprite

**Изменения**

:cl: 
- add: Противогазам, дыхательным маскам, шлемам скафандров, скафандрам, костюмам биозащиты была добавлена защита от болезней.
- tweak: Питательный батончик в аварийных наборах заменён на консервы.
- tweak: В аварийные наборы вернулись космические медипены.
- tweak: Аварийный набор теперь занимает не 3 х 3 а 2 х 2 клеток в инвентаре.
- tweak: Скафандры теперь имеют размер типа Huge и могут поместиться в инвентарь.
