### PR TITLE
[Balance] Surgery healing tweaks

### DIFF
--- a/Content.Server/EntityEffects/Effects/HealthChange.cs
+++ b/Content.Server/EntityEffects/Effects/HealthChange.cs
@@ -7,6 +7,7 @@ using JetBrains.Annotations;
 using Robust.Shared.Prototypes;
 using System.Linq;
 using System.Text.Json.Serialization;
+using Content.Shared.Backmen.Targeting;
 
 namespace Content.Server.EntityEffects.Effects
 {
@@ -124,7 +125,13 @@ namespace Content.Server.EntityEffects.Effects
                 args.TargetEntity,
                 Damage * scale,
                 IgnoreResistances,
-                interruptsDoAfters: false);
+                interruptsDoAfters: false,
+                // start-backmen: surgery
+                targetPart: TargetBodyPart.All,
+                partMultiplier: 0.5f,
+                canSever: false,
+                evade: true);
+                // end-backmen: surgery
         }
     }
 }

--- a/Content.Shared/Backmen/Surgery/Body/SharedBodySystem.Integrity.cs
+++ b/Content.Shared/Backmen/Surgery/Body/SharedBodySystem.Integrity.cs
@@ -26,7 +26,7 @@ public partial class SharedBodySystem
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
-    private readonly string[] _severingDamageTypes = { "Slash", "Pierce", "Blunt" };
+
     private const double IntegrityJobTime = 0.005;
     private readonly JobQueue _integrityJobQueue = new(IntegrityJobTime);
 
@@ -117,7 +117,7 @@ public partial class SharedBodySystem
     /// <summary>
     /// Propagates damage to the specified part of the entity.
     /// </summary>
-    private void ApplyPartDamage(
+    public void ApplyPartDamage(
         Entity<BodyPartComponent> partEnt,
         DamageSpecifier damage,
         BodyPartType targetType,
@@ -126,7 +126,7 @@ public partial class SharedBodySystem
         bool evade,
         float partMultiplier)
     {
-        if (partEnt.Comp.Body is not {} body)
+        if (partEnt.Comp.Body == null)
             return;
 
         _proto.TryIndex<DamageGroupPrototype>("Brute", out var proto);
@@ -134,7 +134,7 @@ public partial class SharedBodySystem
         if (!TryEvadeDamage(partEnt.Comp.Body.Value, GetEvadeChance(targetType)) || evade)
         {
             TryChangeIntegrity(partEnt,
-                damage * partMultiplier,
+                damage * partMultiplier * GetPartDamageModifier(targetType),
                 // This is true when damage contains at least one of the brute damage types
                 canSever && damage.TryGetDamageInGroup(proto!, out var dmg) && dmg > FixedPoint2.Zero,
                 targetPart,
@@ -330,8 +330,8 @@ public partial class SharedBodySystem
         {
             BodyPartType.Head => 0.5f, // 50% damage, necks are hard to cut
             BodyPartType.Torso => 1.0f, // 100% damage
-            BodyPartType.Arm => 0.7f, // 70% damage
-            BodyPartType.Leg => 0.7f, // 70% damage
+            BodyPartType.Arm => 0.8f, // 80% damage
+            BodyPartType.Leg => 0.8f, // 80% damage
             _ => 0.5f
         };
     }
@@ -375,8 +375,6 @@ public partial class SharedBodySystem
             _ => 0f
         };
     }
-
-
 
     public bool CanEvadeDamage(Entity<MobStateComponent?> uid)
     {

--- a/Content.Shared/Backmen/Surgery/Body/SharedBodySystem.Integrity.cs
+++ b/Content.Shared/Backmen/Surgery/Body/SharedBodySystem.Integrity.cs
@@ -129,14 +129,12 @@ public partial class SharedBodySystem
         if (partEnt.Comp.Body == null)
             return;
 
-        _proto.TryIndex<DamageGroupPrototype>("Brute", out var proto);
-
         if (!TryEvadeDamage(partEnt.Comp.Body.Value, GetEvadeChance(targetType)) || evade)
         {
             TryChangeIntegrity(partEnt,
                 damage * partMultiplier * GetPartDamageModifier(targetType),
                 // This is true when damage contains at least one of the brute damage types
-                canSever && damage.TryGetDamageInGroup(proto!, out var dmg) && dmg > FixedPoint2.Zero,
+                canSever,
                 targetPart,
                 out _);
         }
@@ -162,10 +160,13 @@ public partial class SharedBodySystem
         partEnt.Comp.Damage.ExclusiveAdd(damage);
         partEnt.Comp.Damage.ClampMin(partEnt.Comp.MinIntegrity); // No over-healing!
 
+        _proto.TryIndex<DamageGroupPrototype>("Brute", out var proto);
+
         if (canSever
             && !HasComp<BodyPartReattachedComponent>(partEnt)
             && !partEnt.Comp.Enabled
-            && integrity >= partEnt.Comp.SeverIntegrity
+            && partEnt.Comp.Damage.TryGetDamageInGroup(proto!, out var dmg)
+            && dmg > partEnt.Comp.SeverIntegrity
             && partIdSlot is not null)
             severed = true;
 

--- a/Content.Shared/Body/Part/BodyPartComponent.cs
+++ b/Content.Shared/Body/Part/BodyPartComponent.cs
@@ -100,7 +100,7 @@ public sealed partial class BodyPartComponent : Component, ISurgeryToolComponent
     /// to make possible severing it.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float SeverIntegrity = 70;
+    public float SeverIntegrity = 100;
 
     /// <summary>
     /// On what TargetIntegrity we should re-enable the part.
@@ -111,12 +111,12 @@ public sealed partial class BodyPartComponent : Component, ISurgeryToolComponent
     [DataField, AutoNetworkedField]
     public Dictionary<TargetIntegrity, float> IntegrityThresholds = new()
     {
-        { TargetIntegrity.CriticallyWounded, 70 },
-        { TargetIntegrity.HeavilyWounded, 56 },
-        { TargetIntegrity.ModeratelyWounded, 42 },
-        { TargetIntegrity.SomewhatWounded, 28},
+        { TargetIntegrity.CriticallyWounded, 80 },
+        { TargetIntegrity.HeavilyWounded, 65 },
+        { TargetIntegrity.ModeratelyWounded, 48 },
+        { TargetIntegrity.SomewhatWounded, 32 },
         { TargetIntegrity.LightlyWounded, 17 },
-        { TargetIntegrity.Healthy, 7 },
+        { TargetIntegrity.Healthy, 6 },
     };
 
     /// <summary>

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -119,7 +119,7 @@ namespace Content.Shared.Damage
                     targetPart = targeter.Target;
                     // ...Or do we?
                     // If the target is Torso then have a 33% chance to hit another part
-                    if (targetPart.Value.HasFlag(TargetBodyPart.Torso))
+                    if (targetPart.Value == TargetBodyPart.Torso)
                         targetPart = GetRandomPartSpread(_random, 10);
                 }
                 else


### PR DESCRIPTION
# Описание PR
Ребаланс некоторых значений у хирургии и исправления ошибок.

Related to https://github.com/Simple-Station/Einstein-Engines/pull/1159

:cl: Rouden
- tweak: Химикаты теперь могут лечить или наносить урон частям тела.
- fix: Исправлено лечение частей тела, теперь их снова можно лечить при помощи медикаментов!
- fix: Части тела теперь могут быть отрезаны только при получении достаточного количества механического урона.
