### PR TITLE
обновление whitelist логики в ui, обновление требований у цк ролей

### DIFF
--- a/Content.Client/UserInterface/Systems/Ghost/Controls/Roles/GhostRolesEui.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/Roles/GhostRolesEui.cs
@@ -3,6 +3,7 @@ using Content.Client.Eui;
 using Content.Client.Players.PlayTimeTracking;
 using Content.Shared.Eui;
 using Content.Shared.Ghost.Roles;
+using Content.Shared.Players.JobWhitelist;
 using JetBrains.Annotations;
 using Robust.Client.GameObjects;
 using Robust.Shared.Utility;
@@ -94,7 +95,7 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls.Roles
             // TODO: role.Requirements value doesn't work at all as an equality key, this must be fixed
             // Grouping roles
             var groupedRoles = ghostState.GhostRoles.GroupBy(
-                role => (role.Name, role.Description, role.Requirements, role.WhitelistRequired)); //backmen: whitelist
+                role => (role.Name, role.Description, role.Requirements, role.WhitelistRequired, role.DiscordRequired)); //backmen: whitelist
 
             //start-backmen: whitelist
             var cfg = IoCManager.Resolve<Robust.Shared.Configuration.IConfigurationManager>();
@@ -109,14 +110,15 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls.Roles
                 FormattedMessage? reason;
 
                 //start-backmen: whitelist
-                if (
-                    group.Key.WhitelistRequired &&
-                    cfg.GetCVar(Shared.Backmen.CCVar.CCVars.WhitelistRolesEnabled) &&
-                    !requirementsManager.IsWhitelisted()
-                    )
+                if (group.Key.WhitelistRequired)
                 {
                     hasAccess = false;
                     reason = FormattedMessage.FromMarkupOrThrow(Loc.GetString("playtime-deny-reason-not-whitelisted"));
+                }
+                else if (group.Key.DiscordRequired)
+                {
+                    hasAccess = false;
+                    reason = FormattedMessage.FromMarkupOrThrow(Loc.GetString("playtime-deny-reason-discord"));
                 }
                 else
                 //end-backmen: whitelist

--- a/Content.Server/Backmen/Reinforcement/ReinforcementSystem.cs
+++ b/Content.Server/Backmen/Reinforcement/ReinforcementSystem.cs
@@ -7,6 +7,7 @@ using Content.Server.GameTicking;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.Ghost.Roles.Raffles;
 using Content.Server.Mind;
+using Content.Server.Players.JobWhitelist;
 using Content.Server.Players.PlayTimeTracking;
 using Content.Server.Popups;
 using Content.Server.Roles;
@@ -71,6 +72,8 @@ public sealed class ReinforcementSystem : SharedReinforcementSystem
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
     [Dependency] private readonly StationJobsSystem _stationJobs = default!;
     [Dependency] private readonly IChatManager _chatManager = default!;
+    [Dependency] private readonly GameTicker _ticker = default!;
+    [Dependency] private readonly JobWhitelistManager _jobWhitelistManager = default!;
 
     public override void Initialize()
     {
@@ -153,7 +156,10 @@ public sealed class ReinforcementSystem : SharedReinforcementSystem
         if (station == null)
             return;
 
-        var character = HumanoidCharacterProfile.Random();
+        var character = _ticker.GetPlayerProfile(args.Player).Clone();
+        character.Name = HumanoidCharacterProfile.GetName(character.Species, character.Gender);
+
+        //var character = HumanoidCharacterProfile.RandomWithSpecies();
         var newMind = _mind.CreateMind(args.Player.UserId, character.Name);
         _mind.SetUserId(newMind, args.Player.UserId);
 
@@ -206,26 +212,35 @@ public sealed class ReinforcementSystem : SharedReinforcementSystem
         var row = ent.Comp.Linked.Comp.Members.FirstOrDefault(x => x.Owner == ent.Owner);
         if (row == null)
         {
+            ent.Comp.Used = false;
             return;
         }
 
         var proto = ent.Comp.Linked.Comp.GetById(row.Id, _prototype);
         if (proto == null)
         {
+            ent.Comp.Used = false;
             return;
         }
 
-        if (_banManager.GetRoleBans(args.Player.UserId)?.Contains("Job:"+proto.Job) ?? false)
+        if (_banManager.GetJobBans(args.Player.UserId)?.Contains(proto.Job) ?? false)
         {
-            _popup.PopupCursor(Loc.GetString("role-ban"), args.Player, PopupType.LargeCaution);
             ent.Comp.Used = false;
+            SendChatMsg(args.Player, Loc.GetString("role-ban"));
             return;
         }
 
         if (!_playTimeTrackings.IsAllowed(args.Player,proto.Job))
         {
-            _popup.PopupCursor(Loc.GetString("role-timer-locked"), args.Player, PopupType.LargeCaution);
             ent.Comp.Used = false;
+            SendChatMsg(args.Player, Loc.GetString("role-timer-locked"));
+            return;
+        }
+
+        if (!_jobWhitelistManager.IsAllowed(args.Player, proto.Job))
+        {
+            ent.Comp.Used = false;
+            SendChatMsg(args.Player, Loc.GetString("role-not-whitelisted"));
             return;
         }
 
@@ -302,7 +317,9 @@ public sealed class ReinforcementSystem : SharedReinforcementSystem
                 ghost.Requirements = new HashSet<JobRequirement>(job.Requirements);
             }
 
-            ghost.WhitelistRequired = job.Whitelisted;
+            ghost.JobProto = job.ID;
+
+            //ghost.WhitelistRequired = job.Whitelisted;
         }
 
         UpdateUserInterface(ent);
@@ -397,5 +414,17 @@ public sealed class ReinforcementSystem : SharedReinforcementSystem
         }
 
         _ui.SetUiState(uid.Owner, ReinforcementConsoleKey.Key, msg);
+    }
+
+    private void SendChatMsg(ICommonSession sess, string message)
+    {
+        _popup.PopupCursor(message, sess, PopupType.LargeCaution);
+        _chatManager.ChatMessageToOne(Shared.Chat.ChatChannel.Server,
+            message,
+            Loc.GetString("chat-manager-server-wrap-message", ("message", message)),
+            default,
+            false,
+            sess.Channel,
+            Color.Red);
     }
 }

--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -6,6 +6,7 @@ using Content.Server.Ghost.Roles.Events;
 using Content.Shared.Ghost.Roles.Raffles;
 using Content.Server.Ghost.Roles.UI;
 using Content.Server.Mind.Commands;
+using Content.Server.Players.JobWhitelist;
 using Content.Shared.Administration;
 using Content.Shared.CCVar;
 using Content.Shared.Database;
@@ -54,6 +55,8 @@ public sealed class GhostRoleSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _prototype = default!;
 
     [Dependency] private readonly Backmen.RoleWhitelist.WhitelistSystem _roleWhitelist = default!; // backmen: whitelist
+    [Dependency] private readonly JobWhitelistManager _wlRole = default!; // backmen: whitelist
+    [Dependency] private readonly Content.Corvax.Interfaces.Server.IServerDiscordAuthManager _discordAuthManager = default!; // backmen: whitelist
 
     private uint _nextRoleIdentifier;
     private bool _needsUpdateGhostRoleCount = true;
@@ -578,6 +581,27 @@ public sealed class GhostRoleSystem : EntitySystem
                 ? _timing.CurTime.Add(raffle.Countdown)
                 : TimeSpan.MinValue;
 
+            // start-backmen: whitelist
+            var whitelistRequired = false;
+            var discordRequired = false;
+            if (_prototype.TryIndex(role.JobProto, out var job) && player != null)
+            {
+                if (role.WhitelistRequired)
+                {
+                    whitelistRequired = true;
+                }
+                else if (!_wlRole.IsAllowed(player, job))
+                {
+                    whitelistRequired = true;
+                }
+
+                if (_discordAuthManager.IsEnabled && job.DiscordRequired)
+                {
+                    discordRequired = true;
+                }
+            }
+            // end-backmen: whitelist
+
             roles.Add(new GhostRoleInfo
             {
                 Identifier = id,
@@ -588,7 +612,8 @@ public sealed class GhostRoleSystem : EntitySystem
                 Kind = kind,
                 RafflePlayerCount = rafflePlayerCount,
                 RaffleEndTime = raffleEndTime,
-                WhitelistRequired = role.WhitelistRequired // backmen: whitelist
+                WhitelistRequired = whitelistRequired, // backmen: whitelist
+                DiscordRequired = discordRequired, // backmen: whitelist
             });
         }
 

--- a/Content.Shared/Ghost/Roles/GhostRolesEuiMessages.cs
+++ b/Content.Shared/Ghost/Roles/GhostRolesEuiMessages.cs
@@ -12,6 +12,7 @@ namespace Content.Shared.Ghost.Roles
         public string Description { get; set; }
         public string Rules { get; set; }
         public bool WhitelistRequired { get; set; } // backmen: Whitelist
+        public bool DiscordRequired { get; set; } // backmen: Whitelist
 
         // TODO ROLE TIMERS
         // Actually make use of / enforce this requirement?

--- a/Resources/Locale/en-US/backmen/playtime.ftl
+++ b/Resources/Locale/en-US/backmen/playtime.ftl
@@ -1,3 +1,4 @@
 ﻿playtime-deny-reason-not-whitelisted = You need be [color=yellow]Whitelist[/color] to keep this role
+playtime-deny-reason-discord = You should complete [color=yellow]Discord[/color]-auth to keep this role
 ghost-role-whitelist-text = {$num} roles are not shown because they require whitelisting to play.
 ghost-role-whitelist-text-one = One role is not shown because it requires whitelisting to play.

--- a/Resources/Locale/ru-RU/backmen/playtime.ftl
+++ b/Resources/Locale/ru-RU/backmen/playtime.ftl
@@ -1,4 +1,5 @@
 playtime-deny-reason-not-whitelisted = Вам нужно быть в [color=yellow]Whitelist[/color], чтобы взять эту роль
+playtime-deny-reason-discord = Вам нужно пройти [color=yellow]Discord[/color] авторизацию, чтобы взять эту роль
 ghost-role-whitelist-text = { $num } роли(-ей) не показываются, т.к. вы не в Whitelist
 ghost-role-whitelist-text-one = Одна(или больше) ролей не показываются, т.к. вы не в Whitelist
 ui-escape-discord = Написать заявку можно в дискорде

--- a/Resources/Maps/centcomm.yml
+++ b/Resources/Maps/centcomm.yml
@@ -2728,7 +2728,6 @@ entities:
     - type: GasTileOverlay
     - type: SpreaderGrid
     - type: GridPathfinding
-    - type: ProtectedGrid
 - proto: AcousticGuitarInstrument
   entities:
   - uid: 1455

--- a/Resources/Prototypes/_Backmen/CentComm/BKCCAssistant.yml
+++ b/Resources/Prototypes/_Backmen/CentComm/BKCCAssistant.yml
@@ -36,9 +36,10 @@
 
 - type: entity
   name: Ассистент ЦК
-  suffix: Спавнер, Директор Событий
+  suffix: Директор Событий
   parent: MobHumanCombine
   id: MobHumanCMBKCCAssistant
+  description: ""
   components:
   - type: Icon
     sprite: Markers/jobs.rsi

--- a/Resources/Prototypes/_Backmen/CentComm/BKCCCargo.yml
+++ b/Resources/Prototypes/_Backmen/CentComm/BKCCCargo.yml
@@ -41,6 +41,7 @@
   suffix: Директор Событий
   parent: MobHumanCombine
   id: MobHumanCMBKCCCargo
+  description: ""
   components:
   - type: Icon
     sprite: Markers/jobs.rsi
@@ -55,7 +56,7 @@
     factions:
     - CentralCommand
   - type: Loadout
-    prototypes: [CCCargo]
+    prototypes: [CCCargoFull]
   - type: RandomHumanoidAppearance
     randomizeName: true
   - type: AntagImmune

--- a/Resources/Prototypes/_Backmen/CentComm/BKCCOperator.yml
+++ b/Resources/Prototypes/_Backmen/CentComm/BKCCOperator.yml
@@ -38,7 +38,7 @@
   name: Оператор ЦК
   suffix: Директор Событий
   parent: MobHumanCombine
-  description: Офисный клерк.
+  description: Офисный клерк
   id: MobHumanCMBKCCOperator
   components:
   - type: Icon

--- a/Resources/Prototypes/_Backmen/Loadouts/Jobs/CentCom/BKCCCargo.yml
+++ b/Resources/Prototypes/_Backmen/Loadouts/Jobs/CentCom/BKCCCargo.yml
@@ -7,6 +7,18 @@
     shoes: ClothingShoesColorBlack
     head: ClothingHeadHatCargosoft
 
+- type: startingGear
+  id: CCCargoFull
+  equipment:
+    id: CCCargoPDA
+    ears: ClothingHeadsetCentCom
+    pocket1: AppraisalTool
+    shoes: ClothingShoesColorBlack
+    head: ClothingHeadHatCargosoft
+    jumpsuit: ClothingUniformJumpsuitCargo
+    neck: ClothingNeckCloakCap
+    back: ClothingBackpack
+
 
 # Jumpsuit
 - type: loadout

--- a/Resources/Prototypes/_Backmen/Roles/Jobs/CentCom/blueshield.yml
+++ b/Resources/Prototypes/_Backmen/Roles/Jobs/CentCom/blueshield.yml
@@ -7,6 +7,7 @@
   requireAdminNotify: true
   joinNotifyCrew: true
   whitelisted: true
+  discordRequired: true
   requirements:
     - !type:RoleTimeRequirement
       role: JobHeadOfSecurity

--- a/Resources/Prototypes/_Backmen/Roles/Jobs/CentCom/cargotech.yml
+++ b/Resources/Prototypes/_Backmen/Roles/Jobs/CentCom/cargotech.yml
@@ -11,6 +11,7 @@
   weight: 1
   requireAdminNotify: true
   joinNotifyCrew: true
+  discordRequired: true
   requirements:
     - !type:DepartmentTimeRequirement
       department: Cargo

--- a/Resources/Prototypes/_Backmen/Roles/Jobs/CentCom/centcom_admiral.yml
+++ b/Resources/Prototypes/_Backmen/Roles/Jobs/CentCom/centcom_admiral.yml
@@ -12,6 +12,7 @@
   requireAdminNotify: true
   joinNotifyCrew: true
   whitelisted: true
+  discordRequired: true
   requirements:
     - !type:RoleTimeRequirement
       role: JobCentralCommandOperator

--- a/Resources/Prototypes/_Backmen/Roles/Jobs/CentCom/centcom_official.yml
+++ b/Resources/Prototypes/_Backmen/Roles/Jobs/CentCom/centcom_official.yml
@@ -12,6 +12,7 @@
   requireAdminNotify: true
   joinNotifyCrew: true
   whitelisted: true
+  discordRequired: true
   requirements:
     - !type:DepartmentTimeRequirement
       department: CentCom

--- a/Resources/Prototypes/_Backmen/Roles/Jobs/CentCom/head_of_security.yml
+++ b/Resources/Prototypes/_Backmen/Roles/Jobs/CentCom/head_of_security.yml
@@ -12,6 +12,7 @@
   requireAdminNotify: true
   joinNotifyCrew: true
   whitelisted: true
+  discordRequired: true
   requirements:
     - !type:RoleTimeRequirement
       role: JobCentralCommandAssistant

--- a/Resources/Prototypes/_Backmen/Roles/Jobs/CentCom/intern.yml
+++ b/Resources/Prototypes/_Backmen/Roles/Jobs/CentCom/intern.yml
@@ -11,6 +11,7 @@
   weight: 1
   requireAdminNotify: true
   joinNotifyCrew: true
+  discordRequired: true
   requirements:
     - !type:DepartmentTimeRequirement
       department: Engineering

--- a/Resources/Prototypes/_Backmen/Roles/Jobs/CentCom/operator.yml
+++ b/Resources/Prototypes/_Backmen/Roles/Jobs/CentCom/operator.yml
@@ -12,6 +12,7 @@
   requireAdminNotify: true
   joinNotifyCrew: true
   whitelisted: true
+  discordRequired: true
   requirements:
     - !type:RoleTimeRequirement
       role: JobCentralCommandAssistant

--- a/Resources/Prototypes/_Backmen/Roles/Jobs/CentCom/private_officer.yml
+++ b/Resources/Prototypes/_Backmen/Roles/Jobs/CentCom/private_officer.yml
@@ -11,6 +11,7 @@
   weight: 1
   requireAdminNotify: true
   joinNotifyCrew: true
+  discordRequired: true
   requirements:
     - !type:DepartmentTimeRequirement
       department: Security


### PR DESCRIPTION
:cl: 
- tweak: все роли цк требуют дискорт авторизацию!
- tweak: консоль вызова должностных лиц теперь берет вашего персонажа но со случайным именем!
- fix: отображения whitelist в списке ролей
- fix: снаряжения карго цк
- add: теперь цк можно взорвать!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced Discord authentication requirement for various job roles, including `BKCCargo`, `BKCCOfficial`, `BKCCSecGavna`, `BKCCAssistant`, `BKCCOperator`, `BKCCSecOfficer`, `BlueShield`, and `BKCCAdmiral`.
  - Added new entities and improved role management for ghost roles, enhancing user communication regarding role access.

- **Bug Fixes**
  - Refined access control logic for ghost roles, ensuring clearer denial reasons based on Discord and whitelist requirements.

- **Localization**
  - Added new localization strings for Discord authentication denial reasons in both English and Russian.

- **Chores**
  - Updated starting gear configurations for roles to enhance user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->