### PR TITLE
[Hotfix] Inventory slots dissapear at roundstart

### DIFF
--- a/Content.Shared/Inventory/InventorySystem.Slots.cs
+++ b/Content.Shared/Inventory/InventorySystem.Slots.cs
@@ -219,7 +219,7 @@ public partial class InventorySystem : EntitySystem
                     _randomHelper.RandomOffset(entityUid, 0.5f);
                 }
             }
-            slot.Disabled = isDisabled;
+            //slot.Disabled = isDisabled; // Backmen: surgery TURNED OFF FEATURE, would be fixed today maybe with proper limbs cutting disables appropriate slot(-s)
             break;
         }
 


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR
Исправил откатив фичу с исчезанием слотов при отрубании конечностей. Эта фича багованная нужно переписать. Сегодня будет пофикшено, но чтобы игроки не страдали, откатил эту фичу со слотами. Слоты будут левитировать, но зато игроки не будут страдать.
<!-- Опишите здесь ваш Pull Request (PR). Что он изменяет? На что еще это может повлиять? -->

## Технические детали
Система слотов ломается из-за щиткода на стороне оффов. Я просто закомментировал фичу `//slot.Disable = isDisabled;` в `InventorySystem.Slots.cs`. Вот подробности про багу:
> I think I moved everything related to slot disabling/enabling to a centralized function called ChangeSlotState or something?
> its really messy since `inventorycomponent` and `inventoryslotscomponent` are not the same.
> and inventory slots arent networked since it uses a compreg
<!-- Краткое описание изменений в коде для облегчения проверки. -->

## Медиа
![image](https://github.com/user-attachments/assets/b41a7f7e-4662-4613-9f71-71327326c859)

<!-- Добавьте скриншоты/видео, для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте скриншоты, иначе он может быть закрыт. -->

<!-- Место для вашего чек-листа, здесь можно составить список, к примеру того, что вы хотите сделать.
## Чек-лист

- [x] Я сделаю хорошее
-->

## Тип PR
<!-- Подходите ответственно к пометке этих пунктов, для этого необходимо поставить английскую "x" между квадратных скобок -->
- [ ] Feature
- [x] Fix
- [ ] Tweak
- [ ] Balance
- [ ] Refactor
- [ ] Port
- [ ] Translate
- [ ] Resprite

**Изменения**
<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят
Для записей в списке изменений есть 4 значка: add, remove, tweak, fix. Думаю, вы сможете разобраться с остальным.

Вы можете поставить свой ник после символа :cl:, чтобы изменить ник, который будет отображаться в журнале изменений (в противном случае будет использоваться ник вашего аккаунта GitHub)
Например: ":cl: PuroSlavKing".

Как правило, в журналы изменений следует помещать только то, что действительно важно игрокам. Вещи вроде "Рефактор системы X, но изменений вы не увидите" - не должны быть в журнале изменений, эти изменения обычные игроки не смогут заметить.

При написании списка изменений НЕ считайте суффикс типа записи (например, add) "частью" предложения:
Плохо: - add: Хирургия может вырезать яйца.
Хорошо: - add: Добавлена хирургическая операция, которая позволяет вырезать яйца.
-->

:cl: 
- fix: Теперь раундстартом доступны все слоты под перчатки, наушники, ботинки, головной убор, когда ранее они с шансом были недоступны.
- fix: Теперь отрубание конечностей не убирает возможность взаимодействия с слотом под предмет, например отрубание ног позволяет надеть ботинки.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Изменения в функционале**
	- Временно отключена возможность установки статуса слота в системе инвентаря, что может повлиять на управление слотами во время операций, связанных с хирургией и ампутацией.
	- Обновлена сигнатура метода `SetSlotStatus`, убрав параметр `isDisabled`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->