### PR TITLE
[Tweak] Gamemode's weights

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,14 +1,14 @@
 - type: weightedRandom
   id: Secret
   weights: # no_mad NonRP
-    Nukeops: 0.20
+    Nukeops: 0.15
     Traitor: 0.35
     Zombie: 0.10
     Zombieteors: 0.0
     KesslerSyndrome: 0.01
-    Revolutionary: 0.15
+    Revolutionary: 0.10
     FleshCult: 0.15
     Blob: 0.10
-    Survival: 0.10
+    Survival: 0.05
 #    Changeling: 0.20 # Changelings
 #    Traitorling: 0.10 # Changelings

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,14 +1,13 @@
 - type: weightedRandom
   id: Secret
   weights: # no_mad NonRP
-    Nukeops: 0.15
+    Nukeops: 0.14
     Traitor: 0.35
     Zombie: 0.10
-    Zombieteors: 0.0
+#   Zombieteors: 0.01
     KesslerSyndrome: 0.01
     Revolutionary: 0.10
     FleshCult: 0.15
     Blob: 0.10
     Survival: 0.05
-#    Changeling: 0.20 # Changelings
-#    Traitorling: 0.10 # Changelings
+#   Changeling: 0.20 # After fix changelings with surgery

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,13 +1,15 @@
 - type: weightedRandom
   id: Secret
   weights: # no_mad NonRP
-    Nukeops: 0.14
-    Traitor: 0.35
+    Nukeops: 0.15
+    Traitor: 0.24
     Zombie: 0.10
 #   Zombieteors: 0.01
     KesslerSyndrome: 0.01
     Revolutionary: 0.10
-    FleshCult: 0.15
+    FleshCult: 0.10
     Blob: 0.10
     Survival: 0.05
+    ExtendedThief: 0.10
+    Vampires: 0.05
 #   Changeling: 0.20 # After fix changelings with surgery


### PR DESCRIPTION
# Описание PR
People are boring with survival, yoooo!
И цифры подправил, да.
## Тип PR
- [x] Tweak


**Изменения**

:cl: Warete

- tweak: Изменены шансы на выпадение некоторых режимов игры: Ядерные оперативники, Революция и Выживание стали реже.
- add: В секрете теперь могут выпасть режимы Воров или Вампиров.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Обновление

- **Изменения в функциональности**
	- Обновлены веса для сущностей: `Nukeops`, `Traitor`, `Revolutionary`, `FleshCult`, `Survival`.
		- `Nukeops`: 0.20 → 0.15
		- `Traitor`: 0.35 → 0.24
		- `Revolutionary`: 0.15 → 0.10
		- `FleshCult`: 0.15 → 0.10
		- `Survival`: 0.10 → 0.05
	- Вес для `Zombieteors` закомментирован.
	- Добавлены новые веса для `ExtendedThief` и `Vampires`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->