### PR TITLE
[Fix/Tweak] Bodybags with Laying system

### DIFF
--- a/Content.Shared/Morgue/EntityStorageLayingDownOverrideSystem.cs
+++ b/Content.Shared/Morgue/EntityStorageLayingDownOverrideSystem.cs
@@ -1,4 +1,6 @@
 using Content.Shared.Body.Components;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Mobs.Systems;
 using Content.Shared.Morgue.Components;
 using Content.Shared.Standing;
 using Content.Shared.Storage.Components;
@@ -8,6 +10,7 @@ namespace Content.Shared.Morgue;
 public sealed class EntityStorageLayingDownOverrideSystem : EntitySystem
 {
     [Dependency] private readonly StandingStateSystem _standing = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
 
     public override void Initialize()
     {
@@ -20,7 +23,7 @@ public sealed class EntityStorageLayingDownOverrideSystem : EntitySystem
     {
         foreach (var ent in args.Contents)
         {
-            if (HasComp<BodyComponent>(ent) && !_standing.IsDown(ent))
+            if (HasComp<BodyComponent>(ent) && (!_standing.IsDown(ent) || !_mobState.IsDead(ent)))
                 args.Contents.Remove(ent);
         }
     }

--- a/Resources/Prototypes/Entities/Structures/Storage/morgue.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/morgue.yml
@@ -44,7 +44,6 @@
       path: /Audio/Items/deconstruct.ogg
     openSound:
       path: /Audio/Items/deconstruct.ogg
-  - type: EntityStorageLayingDownOverride
   - type: Morgue
   - type: ContainerContainer
     containers:
@@ -121,7 +120,6 @@
       path: /Audio/Items/deconstruct.ogg
     openSound:
       path: /Audio/Items/deconstruct.ogg
-  - type: EntityStorageLayingDownOverride
   - type: Crematorium
   - type: ContainerContainer
     containers:


### PR DESCRIPTION
# Описание PR
Thx to Remuchi

Игроки более не могут находиться в мешке для трупов **Не Мёртвыми**.
В крематорий и морг можно "лечь" снова стоя.

## Тип PR
- [x] Tweak
- [x] Fix

**Изменения**

:cl: Warete

- tweak: В крематорий и морг можно вновь "лечь" стоя.
- fix: Теперь мешки для трупов **укладываются** только трупы.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Новые функции**
  - Добавлены новые компоненты `EntityStorageLayingDownOverride` для объектов Морга и Крематория, улучшая управление содержимым.
  - Обновлены визуальные элементы для состояния объектов, включая индикаторы и визуализацию для различных состояний.

- **Исправления ошибок**
  - Изменена логика удаления сущностей из хранения, позволяя оставлять сущности в состоянии "лежит", если они не мертвы.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->