### PR TITLE
[Feature] Lathe Arbitrage Integration Test

### DIFF
--- a/Content.IntegrationTests/Tests/Backmen/Lathe/LatheRecipyCostTest.cs
+++ b/Content.IntegrationTests/Tests/Backmen/Lathe/LatheRecipyCostTest.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using Content.Server.Cargo.Systems;
+using Content.Shared.Research.Prototypes;
+
+namespace Content.IntegrationTests.Tests.Backmen.Lathe;
+
+[TestFixture]
+public sealed class LatheRecipyCostTest
+{
+    private const double Tolerance = 10;
+
+    [Test]
+    public async Task LatheRecipesNoArbitrageTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+
+        var server = pair.Server;
+        var proto = server.ProtoMan;
+        var entMan = server.EntMan;
+        var priceSystem = entMan.System<PricingSystem>();
+
+        var fails = new List<string>();
+
+        await server.WaitAssertion(() =>
+        {
+            var recipes = proto.EnumeratePrototypes<LatheRecipePrototype>();
+            foreach (var recipe in recipes)
+            {
+                var resultPrice = Math.Round(priceSystem.GetLatheRecipePrice(recipe));
+                var matPrice = 0.0;
+                bool ignoreRecipe = false;
+                foreach (var (materialId, count) in recipe.Materials)
+                {
+                    var material = proto.Index(materialId);
+
+                    if (material.IgnoreArbitrage)
+                        ignoreRecipe = true;
+
+                    matPrice += material.Price * count;
+                }
+
+                if (ignoreRecipe)
+                    continue;
+
+                matPrice = Math.Round(matPrice);
+
+                if (resultPrice > matPrice + Tolerance)
+                {
+                    fails.Add($"ID: {recipe.ID} Materials: {matPrice} Result: {resultPrice} Dif: {resultPrice - matPrice}");
+                }
+            }
+        });
+
+        if (fails.Count > 0)
+        {
+            var msg = string.Join("\n", fails) + "\n" + "Following RecipePrototypes are giving Arbitrage when printed!";
+            Assert.Fail(msg);
+        }
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Shared/Materials/MaterialPrototype.cs
+++ b/Content.Shared/Materials/MaterialPrototype.cs
@@ -56,5 +56,12 @@ namespace Content.Shared.Materials
         /// </summary>
         [DataField(required: true)]
         public double Price = 0;
+
+        /// <summary>
+        /// Backmen Change: Setting this to true will make
+        /// this material be ignored in Price Tests.
+        /// </summary>
+        [DataField]
+        public bool IgnoreArbitrage;
     }
 }

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -402,7 +402,7 @@
     - type: Sprite
       state: cpu_service
     - type: StaticPrice
-      price: 150
+      price: 100
     - type: ComputerBoard
       prototype: ComputerMassMedia
 

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/misc.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/misc.yml
@@ -13,4 +13,4 @@
     tags:
       - StationMapElectronics
   - type: StaticPrice
-    price: 30
+    price: 20

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/misc.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/misc.yml
@@ -12,5 +12,3 @@
   - type: Tag
     tags:
       - StationMapElectronics
-  - type: StaticPrice
-    price: 20

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/base_electronics.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/base_electronics.yml
@@ -11,7 +11,7 @@
     sprite: Objects/Misc/module.rsi
     state: generic
   - type: StaticPrice
-    price: 100
+    price: 45
   - type: PhysicalComposition
     materialComposition:
       Glass: 200

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/door.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/door.yml
@@ -11,8 +11,6 @@
       tags:
         - DoorElectronics
     - type: DoorElectronics
-    - type: StaticPrice
-      price: 20
     - type: AccessReader
     - type: ActivatableUI
       key: enum.DoorElectronicsConfigurationUiKey.Key

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/door.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/door.yml
@@ -12,7 +12,7 @@
         - DoorElectronics
     - type: DoorElectronics
     - type: StaticPrice
-      price: 55
+      price: 20
     - type: AccessReader
     - type: ActivatableUI
       key: enum.DoorElectronicsConfigurationUiKey.Key

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/firelock.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/firelock.yml
@@ -12,5 +12,3 @@
     - type: Tag
       tags:
       - FirelockElectronics
-    - type: StaticPrice
-      price: 20

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/firelock.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/firelock.yml
@@ -13,4 +13,4 @@
       tags:
       - FirelockElectronics
     - type: StaticPrice
-      price: 61
+      price: 20

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/misc.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/misc.yml
@@ -12,4 +12,4 @@
       - FreezerElectronics
   - type: DoorElectronics
   - type: StaticPrice
-    price: 55
+    price: 20

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/misc.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/misc.yml
@@ -11,5 +11,3 @@
     tags:
       - FreezerElectronics
   - type: DoorElectronics
-  - type: StaticPrice
-    price: 20

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/timer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/timer.yml
@@ -15,7 +15,7 @@
     tags:
     - TimerSignalElectronics
   - type: StaticPrice
-    price: 30
+    price: 20
 
 - type: entity
   id: ScreenTimerElectronics

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/timer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/timer.yml
@@ -14,8 +14,6 @@
   - type: Tag
     tags:
     - TimerSignalElectronics
-  - type: StaticPrice
-    price: 20
 
 - type: entity
   id: ScreenTimerElectronics

--- a/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
@@ -66,7 +66,7 @@
     tags:
       - HolofanProjector
   - type: StaticPrice
-    price: 80
+    price: 60
 
 - type: entity
   parent: HolofanProjector

--- a/Resources/Prototypes/Entities/Objects/Misc/space_cash.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/space_cash.yml
@@ -53,6 +53,7 @@
   stackEntity: SpaceCash
   icon: { sprite: /Textures/Objects/Economy/cash.rsi, state: cash }
   price: 1
+  ignoreArbitrage: true # lathe-test change # uhhhh no
 
 - type: stack
   id: Credit

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -586,6 +586,4 @@
                   min: 2
                   max: 2
     - type: StaticPrice
-      price: 250
-
-
+      price: 170

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -388,6 +388,8 @@
     - type: Battery
       maxCharge: 10000
       startingCharge: 10000
+    - type: StaticPrice
+      price: 300
 
 - type: entity
   name: x-ray cannon

--- a/Resources/Prototypes/Reagents/Materials/materials.yml
+++ b/Resources/Prototypes/Reagents/Materials/materials.yml
@@ -6,6 +6,7 @@
   icon: { sprite: /Textures/Objects/Misc/monkeycube.rsi, state: cube }
   color: "#8A9A5B"
   price: 0.1
+  ignoreArbitrage: true # lathe-test change # We don't care about biomass too much...
 
 - type: material
   id: Cardboard
@@ -14,6 +15,7 @@
   icon: { sprite: /Textures/Objects/Materials/materials.rsi, state: cardboard }
   color: "#70736c"
   price: 0.025
+  ignoreArbitrage: true # lathe-test change
 
 - type: material
   id: Cloth
@@ -41,6 +43,7 @@
   icon: { sprite: Objects/Materials/Sheets/other.rsi, state: paper }
   color: "#d9d9d9"
   price: 0.01 # it's paper bro what do you expect?
+  ignoreArbitrage: true # lathe-test change
 
 - type: material
   id: Plasma

--- a/Resources/Prototypes/Reagents/Materials/materials.yml
+++ b/Resources/Prototypes/Reagents/Materials/materials.yml
@@ -94,6 +94,7 @@
   icon: { sprite: Objects/Materials/Sheets/meaterial.rsi, state: meat }
   color: "#c53648"
   price: 0.05
+  ignoreArbitrage: true # lathe-test change
 
 - type: material
   id: WebSilk

--- a/Resources/Prototypes/Reagents/Materials/ores.yml
+++ b/Resources/Prototypes/Reagents/Materials/ores.yml
@@ -5,6 +5,7 @@
   unit: materials-unit-chunk
   icon: { sprite: Objects/Materials/ore.rsi, state: iron }
   price: 0.05
+  ignoreArbitrage: true # lathe-test change
 
 - type: material
   id: RawQuartz
@@ -14,6 +15,7 @@
   icon: { sprite: Objects/Materials/ore.rsi, state: spacequartz }
   color: "#a8ccd7"
   price: 0.075
+  ignoreArbitrage: true # lathe-test change
 
 - type: material
   id: RawGold
@@ -23,6 +25,7 @@
   icon: { sprite: Objects/Materials/ore.rsi, state: gold }
   color: "#FFD700"
   price: 0.2
+  ignoreArbitrage: true # lathe-test change
 
 - type: material
   id: RawDiamond
@@ -32,6 +35,7 @@
   icon: { sprite: Objects/Materials/ore.rsi, state: diamond }
   color: "#C9D8F2"
   price: 0.5
+  ignoreArbitrage: true # lathe-test change
 
 - type: material
   id: RawSilver
@@ -41,6 +45,7 @@
   icon: { sprite: Objects/Materials/ore.rsi, state: silver }
   color: "#C0C0C0"
   price: 0.15
+  ignoreArbitrage: true # lathe-test change
 
 - type: material
   id: RawPlasma
@@ -50,6 +55,7 @@
   icon: { sprite: Objects/Materials/ore.rsi, state: plasma }
   color: "#7e009e"
   price: 0.2
+  ignoreArbitrage: true # lathe-test change
 
 - type: material
   id: RawUranium
@@ -59,6 +65,7 @@
   icon: { sprite: Objects/Materials/ore.rsi, state: uranium }
   color: "#32a852"
   price: 0.2
+  ignoreArbitrage: true # lathe-test change
 
 - type: material
   id: RawBananium
@@ -68,6 +75,7 @@
   icon: { sprite: Objects/Materials/ore.rsi, state: bananium }
   color: "#32a852"
   price: 0.2
+  ignoreArbitrage: true # lathe-test change
 
 - type: material
   id: RawSalt
@@ -77,3 +85,4 @@
   icon: { sprite: Objects/Materials/ore.rsi, state: salt }
   color: "#f5e7d7"
   price: 0.075
+  ignoreArbitrage: true # lathe-test change

--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -15,7 +15,7 @@
   id: BaseCheapElectronicsRecipe
   materials:
     Steel: 100
-    Plastic: 50
+    Plastic: 150
 
 - type: latheRecipe
   abstract: true

--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -14,7 +14,7 @@
   parent: BaseElectronicsRecipe
   id: BaseCheapElectronicsRecipe
   materials:
-    Steel: 50
+    Steel: 100
     Plastic: 50
 
 - type: latheRecipe

--- a/Resources/Prototypes/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/medical.yml
@@ -101,7 +101,7 @@
   result: ClothingMaskSterile
   completetime: 2
   materials:
-    Plastic: 50
+    Plastic: 100
 
 - type: latheRecipe
   id: DiseaseSwab

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -75,9 +75,9 @@
   id: WeaponLaserPistol
   result: WeaponEarthGovLaserPistol
   materials:
-    Steel: 500
-    Glass: 100
-    Plastic: 200
+    Steel: 800
+    Glass: 400
+    Plastic: 400
 
 - type: latheRecipe
   parent: BaseWeaponRecipeLong
@@ -116,8 +116,8 @@
   materials:
     Steel: 1500
     Glass: 500
-    Plastic: 250
-    Gold: 100
+    Plastic: 400
+    Gold: 200
 
 - type: latheRecipe
   id: ClothingBackpackElectropack

--- a/Resources/Prototypes/_Backmen/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/_Backmen/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -9,7 +9,7 @@
     - type: ComputerBoard
       prototype: ComputerShipyard
     - type: StaticPrice
-      price: 750
+      price: 150
 
 - type: entity
   parent: BaseComputerCircuitboard

--- a/Resources/Prototypes/_Backmen/Entities/Objects/Weapons/Guns/Energy/energy.yml
+++ b/Resources/Prototypes/_Backmen/Entities/Objects/Weapons/Guns/Energy/energy.yml
@@ -171,6 +171,8 @@
     steps: 3
     zeroVisible: true
   - type: Appearance
+  - type: StaticPrice
+    price: 250
 
 - type: entity
   name: EarthGov heavy laser rifle

--- a/Resources/Prototypes/_Backmen/Reagents/Materials/prizeticket.yml
+++ b/Resources/Prototypes/_Backmen/Reagents/Materials/prizeticket.yml
@@ -4,3 +4,4 @@
   name: prize ticket
   icon: { sprite: Backmen/Objects/Fun/prizeticket.rsi, state: ticket }
   price: 0
+  ignoreArbitrage: true # lathe-test change


### PR DESCRIPTION
# Описание PR
Добавлен тест на проверку стоимости всех рецептов из автолатов.
Если какой-либо рецепт в результате даёт больше чем материалы необходимые для него, то тест проваливается и выдаёт ошибку!

:cl: Evil Lathe Fixer
- fix: Все рецепты, которые давали возможность зарабатывать в Карго, были исправлены.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Тесты**
	- Добавлен новый тест для проверки цен на рецепты токарного станка, исключающий возможность арбитража.

- **Новые возможности**
	- Введено свойство `IgnoreArbitrage` для материалов.
	- Добавлена возможность исключать определенные материалы из проверок цен.

- **Изменения в конфигурации**
	- Установлено свойство `ignoreArbitrage: true` для нескольких материалов, включая кредиты, биомассу, руды и другие специальные материалы.
	- Изменены требования к материалам для рецептов, увеличив количество необходимых ресурсов для некоторых предметов, таких как `WeaponLaserPistol` и `WeaponXrayCannon`.
	- Изменены цены на некоторые электронные устройства, включая `HolofanProjector` и `TelescopicShield`, улучшая баланс в игре.

Эти изменения направлены на улучшение системы ценообразования в игре и обеспечение экономической сбалансированности.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->