### PR TITLE
Captain saber rebalance

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -31,11 +31,11 @@
     attackRate: 1.5
     damage:
       types:
-        Slash: 17 #cmon, it has to be at least BETTER than the rest.
+        Slash: 19 #кто скажет про дисбаланс, я знаю где вы все живёте
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
   - type: Reflect
-    reflectProb: .1
+    reflectProb: .45
     spread: 90
   - type: Item
     sprite: Objects/Weapons/Melee/captain_sabre.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -31,11 +31,11 @@
     attackRate: 1.5
     damage:
       types:
-        Slash: 19 #кто скажет про дисбаланс, я знаю где вы все живёте
+        Slash: 19 #кто скажет про дисбаланс, я знаю где вы все живёте     #Backmen edit
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
   - type: Reflect
-    reflectProb: .45
+    reflectProb: .45                                                      #Backmen edit
     spread: 90
   - type: Item
     sprite: Objects/Weapons/Melee/captain_sabre.rsi


### PR DESCRIPTION
# Описание PR
Данный PR возвращает старые характеристики сабли капитана.

## Тип PR
- [ ] Feature
- [ ] Fix
- [x] Tweak
- [x] Balance
- [ ] Refactor
- [ ] Port
- [ ] Translate
- [ ] Resprite

**Изменения**

:cl: 
- tweak: Шанс отражения капитанской сабли изменён с 5% до 45%.
- tweak: Урон капитанской сабли изменён с 17 до 19.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Новые возможности**
	- Добавлен новый меч «EnergyKatana» с уникальными активными способностями (рывок, ограниченные заряды, автоматическая подзарядка) и высоким уроном от разреза.

- **Изменения баланса**
	- Оружие «CaptainSabre» теперь наносит повышенный урон от разреза и имеет улучшенную вероятность отражения.
	- «Throngler» получил обновлённые показатели урона по разным типам и изменённую вероятность отражения для более сбалансированного игрового процесса.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->