### PR TITLE
Hotfix Lavaland Shittle

### DIFF
--- a/Content.Server/Maps/GameMapPrototype.cs
+++ b/Content.Server/Maps/GameMapPrototype.cs
@@ -23,7 +23,7 @@ public sealed partial class GameMapPrototype : IPrototype
     public string ID { get; private set; } = default!;
 
     [DataField]
-    public float MaxRandomOffset = 1000f;
+    public float MaxRandomOffset = 0f; // backmen: remove random offset
 
     /// <summary>
     /// Turns out some of the map files are actually secretly grids. Excellent. I love map loading code.
@@ -31,7 +31,7 @@ public sealed partial class GameMapPrototype : IPrototype
     [DataField] public bool IsGrid;
 
     [DataField]
-    public bool RandomRotation = true;
+    public bool RandomRotation = false; // backmen: remove random rotation
 
     /// <summary>
     /// Name of the map to use in generic messages, like the map vote.


### PR DESCRIPTION
теперь станция всегда спавнится на 0,0 без поворота что будет удобно не только для будущих механик, но и вообще везде и всегда и по всем причинам. А ещё только так шаттл лавы будет работать

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Обновлена генерация карт: случайное смещение и поворот отключены для более предсказуемого поведения.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->