### PR TITLE
[Fix] Конец столовых войн

### DIFF
--- a/Content.Shared/Physics/CollisionGroup.cs
+++ b/Content.Shared/Physics/CollisionGroup.cs
@@ -68,7 +68,7 @@ public enum CollisionGroup
 
     // Tables that SmallMobs can go under
     TableMask = Impassable | MidImpassable | BlobImpassable,
-    TableLayer = MidImpassable,
+    TableLayer = MidImpassable | BulletImpassable,
 
     // Tabletop machines, windoors, firelocks
     TabletopMachineMask = Impassable | HighImpassable | BlobImpassable,


### PR DESCRIPTION
Теперь при наведении на стол пули будут попадать в него

:cl: Rouden
- fix: Исправлены столовые войны. Теперь при наведении на стол пули будут попадать в него и со временем ломать.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Новые возможности**
  - Расширено физическое взаимодействие в игровом мире: объекты теперь учитывают столкновения с пулями при взаимодействии со столами, что приводит к более точной и предсказуемой симуляции физических столкновений.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->