### PR TITLE
Fix Bacchus's sprite

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
@@ -2309,7 +2309,7 @@
       drink:
         maxVol: 30
         reagents:
-        - ReagentId: Daiquiri 
+        - ReagentId: Daiquiri
           Quantity: 30
   - type: Icon
     sprite: Objects/Consumable/Drinks/daiquiri.rsi
@@ -2541,5 +2541,5 @@
         - ReagentId: BacchusBlessing
           Quantity: 30
   - type: Icon
-    sprite: Objects/Consumable/Drinks/bacchusblessing.rsi
+    sprite: Backmen/Objects/Consumable/Drinks/bacchus.rsi
     state: icon

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -1399,7 +1399,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.2 
+        amount: 0.2
 
 - type: reagent
   id: PinaColada
@@ -1422,7 +1422,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.2  
+        amount: 0.2
 
 - type: reagent
   id: Sbiten
@@ -1975,7 +1975,7 @@
           time: 1.0
           type: Remove
   fizziness: 0.25
-  
+
 - type: reagent
   id: BlueHawaiian
   name: reagent-name-blue-hawaiian
@@ -2046,8 +2046,8 @@
         amount: 0.2
       - !type:AdjustReagent
         reagent: Copper
-        amount: 0.05        
-        
+        amount: 0.05
+
 - type: reagent
   id: Mimeosa
   name: reagent-name-mimeosa
@@ -2096,7 +2096,7 @@
       - !type:AdjustReagent
         reagent: Ethanol
         amount: 0.07
-        
+
 - type: reagent
   id: Mayojito
   name: reagent-name-mayojito
@@ -2197,7 +2197,7 @@
       - !type:AdjustReagent
         reagent: Ethanol
         amount: 0.2
-        
+
 - type: reagent
   id: Daiquiri
   name: reagent-name-daiquiri
@@ -2220,7 +2220,7 @@
       - !type:AdjustReagent
         reagent: Ethanol
         amount: 0.1
-        
+
 - type: reagent
   id: TheSunAlsoRises
   name: reagent-name-the-sun-also-rises
@@ -2299,11 +2299,8 @@
   flavor: bacchusblessing
   color: "#331303"
   metamorphicSprite:
-    sprite: Objects/Consumable/Drinks/bacchusblessing.rsi
-    state: icon_empty
-  metamorphicMaxFillLevels: 2
-  metamorphicFillBaseName: fill-
-  metamorphicChangeColor: false
+    sprite: Backmen/Objects/Consumable/Drinks/bacchus.rsi
+    state: icon
   metabolisms:
     Drink:
       effects:


### PR DESCRIPTION
# Описание PR
У Бахуса возвращён старый спрайт

:cl: Rouden
- fix: Исправлен спрайт Бахуса, теперь он остался навеки легендарным. Мы так вернулись.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Стиль**
  - Улучшено форматирование конфигураций напитков и ингредиентов для повышения единообразия отображения.
- **Новые возможности**
  - Обновлены пути к изображениям и настройки состояний для напитка Bacchus Blessing, что может способствовать корректному визуальному представлению.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->