### PR TITLE
[Feature] Play time server

### DIFF
--- a/Content.Server/Database/ServerDbBase.cs
+++ b/Content.Server/Database/ServerDbBase.cs
@@ -560,7 +560,7 @@ namespace Content.Server.Database
             if (_playtimeServerEnabled)
             {
                 var requestUrl = $"{_playtimeServerUrl}?playerId={WebUtility.UrlEncode(player.ToString())}";
-                var response = await _httpClient.PostAsync(requestUrl, null, cancel);
+                var response = await _httpClient.GetAsync(requestUrl, cancel);
                 if (!response.IsSuccessStatusCode)
                 {
                     return [];

--- a/Content.Server/Database/ServerDbBase.cs
+++ b/Content.Server/Database/ServerDbBase.cs
@@ -2,6 +2,8 @@ using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading;
@@ -27,6 +29,10 @@ namespace Content.Server.Database
     public abstract class ServerDbBase
     {
         private readonly ISawmill _opsLog;
+        protected string _playtimeServerUrl = String.Empty;
+        protected bool _playtimeServerSaveLocally = false;
+        protected bool _playtimeServerEnabled = false;
+        protected readonly HttpClient _httpClient = new();
 
         public event Action<DatabaseNotification>? OnNotificationReceived;
 
@@ -551,6 +557,18 @@ namespace Content.Server.Database
         #region Playtime
         public async Task<List<PlayTime>> GetPlayTimes(Guid player, CancellationToken cancel)
         {
+            if (_playtimeServerEnabled)
+            {
+                var requestUrl = $"{_playtimeServerUrl}?playerId={WebUtility.UrlEncode(player.ToString())}";
+                var response = await _httpClient.PostAsync(requestUrl, null, cancel);
+                if (!response.IsSuccessStatusCode)
+                {
+                    return [];
+                }
+                var data = await response.Content.ReadFromJsonAsync<List<PlayTime>>(cancel);
+                return data!;
+            }
+
             await using var db = await GetDb(cancel);
 
             return await db.DbContext.PlayTime
@@ -560,6 +578,21 @@ namespace Content.Server.Database
 
         public async Task UpdatePlayTimes(IReadOnlyCollection<PlayTimeUpdate> updates)
         {
+            if (_playtimeServerEnabled)
+            {
+                var data = updates.Select(x => new PlayTime()
+                {
+                    PlayerId = x.User.UserId,
+                    Tracker = x.Tracker,
+                    TimeSpent = x.Time
+                });
+                await _httpClient.PostAsJsonAsync(_playtimeServerUrl, data);
+                if (!_playtimeServerSaveLocally)
+                {
+                    return;
+                }
+            }
+
             await using var db = await GetDb();
 
             // Ideally I would just be able to send a bunch of UPSERT commands, but EFCore is a pile of garbage.

--- a/Content.Server/Database/ServerDbPostgres.cs
+++ b/Content.Server/Database/ServerDbPostgres.cs
@@ -3,6 +3,7 @@ using System.Data;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
+using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -53,6 +54,13 @@ namespace Content.Server.Database
             });
 
             cfg.OnValueChanged(CCVars.DatabasePgFakeLag, v => _msLag = v, true);
+            cfg.OnValueChanged(Shared.Backmen.CCVar.CCVars.PlayTimeServerUrl, v => _playtimeServerUrl = v, true);
+            cfg.OnValueChanged(Shared.Backmen.CCVar.CCVars.PlayTimeServerApiKey, v =>
+            {
+                _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", v);
+            }, true);
+            cfg.OnValueChanged(Shared.Backmen.CCVar.CCVars.PlayTimeServerSaveLocally, v => _playtimeServerSaveLocally = v, true);
+            cfg.OnValueChanged(Shared.Backmen.CCVar.CCVars.PlayTimeServerEnabled, v => _playtimeServerEnabled = v, true);
 
             InitNotificationListener(connectionString);
         }

--- a/Content.Server/Database/ServerDbSqlite.cs
+++ b/Content.Server/Database/ServerDbSqlite.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
+using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -63,6 +64,13 @@ namespace Content.Server.Database
             }
 
             cfg.OnValueChanged(CCVars.DatabaseSqliteDelay, v => _msDelay = v, true);
+            cfg.OnValueChanged(Shared.Backmen.CCVar.CCVars.PlayTimeServerUrl, v => _playtimeServerUrl = v, true);
+            cfg.OnValueChanged(Shared.Backmen.CCVar.CCVars.PlayTimeServerApiKey, v =>
+            {
+                _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", v);
+            }, true);
+            cfg.OnValueChanged(Shared.Backmen.CCVar.CCVars.PlayTimeServerSaveLocally, v => _playtimeServerSaveLocally = v, true);
+            cfg.OnValueChanged(Shared.Backmen.CCVar.CCVars.PlayTimeServerEnabled, v => _playtimeServerEnabled = v, true);
         }
 
         #region Ban

--- a/Content.Shared/Backmen/CCVar/CCVars.PlayTime.cs
+++ b/Content.Shared/Backmen/CCVar/CCVars.PlayTime.cs
@@ -1,0 +1,18 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared.Backmen.CCVar;
+
+public sealed partial class CCVars
+{
+    public static readonly CVarDef<bool> PlayTimeServerEnabled =
+        CVarDef.Create("playtimeServer.enabled", false, CVar.SERVER | CVar.REPLICATED);
+
+    public static readonly CVarDef<string> PlayTimeServerUrl =
+        CVarDef.Create("playtimeServer.api_url", "", CVar.SERVERONLY);
+
+    public static readonly CVarDef<string> PlayTimeServerApiKey =
+        CVarDef.Create("playtimeServer.api_key", "", CVar.SERVERONLY | CVar.CONFIDENTIAL);
+
+    public static readonly CVarDef<bool> PlayTimeServerSaveLocally =
+        CVarDef.Create("playtimeServer.also_save_locally", false, CVar.SERVERONLY);
+}


### PR DESCRIPTION
# Описание PR
Теперь есть поддержка внешнего сервера для работы с PlayTime.

## Тип PR
- [ x ] Feature

:cl: 
- add: Добавлена поддержка сервера наигранного времени.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Новые возможности**
	- Добавлена интеграция с сервером учёта игрового времени, что позволяет получать и обновлять данные об игровом времени через специализированные HTTP-запросы.
	- Реализована динамическая настройка параметров сервера, включая задание URL, использование API-ключа, режим локального сохранения и возможность включения или отключения функции учёта игрового времени.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->