### PR TITLE
[Fix] Make RnD servers local

### DIFF
--- a/Content.Server/Backmen/Disease/VaccineSystem.cs
+++ b/Content.Server/Backmen/Disease/VaccineSystem.cs
@@ -152,7 +152,8 @@ public sealed class VaccineSystem : EntitySystem
 
     private void OnServerSelected(EntityUid uid, DiseaseVaccineCreatorComponent component, ResearchClientServerSelectedMessage args)
     {
-        if (!_research.TryGetServerById(args.ServerId, Transform(uid).MapID, out var serverUid, out var serverComponent))
+        var xform = Transform(uid);
+        if (!_research.TryGetServerById(args.ServerId, xform.MapID, out var serverUid, out var serverComponent))
             return;
 
         if (!TryComp<DiseaseServerComponent>(serverUid, out var diseaseServer))

--- a/Content.Server/Backmen/Disease/VaccineSystem.cs
+++ b/Content.Server/Backmen/Disease/VaccineSystem.cs
@@ -152,7 +152,7 @@ public sealed class VaccineSystem : EntitySystem
 
     private void OnServerSelected(EntityUid uid, DiseaseVaccineCreatorComponent component, ResearchClientServerSelectedMessage args)
     {
-        if (!_research.TryGetServerById(args.ServerId, out var serverUid, out var serverComponent))
+        if (!_research.TryGetServerById(args.ServerId, Transform(uid).MapID, out var serverUid, out var serverComponent))
             return;
 
         if (!TryComp<DiseaseServerComponent>(serverUid, out var diseaseServer))

--- a/Content.Server/Research/Systems/ResearchSystem.Client.cs
+++ b/Content.Server/Research/Systems/ResearchSystem.Client.cs
@@ -94,10 +94,11 @@ public sealed partial class ResearchSystem
         var mapId = Transform(uid).MapID;
 
         // backmen change start
-        var names = GetAvailableServerNames(mapId).ToArray();
-        var state = new ResearchClientBoundInterfaceState(names.Length,
-            names,
-            GetAvailableServerIds(mapId).ToArray(),
+        var servers = GetAvailableServers(mapId).ToArray();
+
+        var state = new ResearchClientBoundInterfaceState(servers.Length,
+            servers.Select(x => x.Comp.ServerName).ToArray(),
+            servers.Select(x => x.Comp.Id).ToArray(),
             serverComponent?.Id ?? -1);
         // backmen change end
 

--- a/Content.Server/Research/Systems/ResearchSystem.cs
+++ b/Content.Server/Research/Systems/ResearchSystem.cs
@@ -105,43 +105,20 @@ namespace Content.Server.Research.Systems
         /// <summary>
         /// Gets the names of all the servers.
         /// </summary>
-        public IEnumerable<string> GetAvailableServerNames(MapId mapId)
+        public IEnumerable<Entity<ResearchServerComponent>> GetAvailableServers(MapId mapId)
         {
             var allServers = EntityQueryEnumerator<ResearchServerComponent, TransformComponent>();
-            var list = new List<string>();
 
-            while (allServers.MoveNext(out var server, out var xform))
+            while (allServers.MoveNext(out var uid, out var server, out var xform))
             {
                 // backmen edit: RnD servers are local for a map
                 if (xform.MapID != mapId)
                     continue;
                 // backmen edit end
 
-                list.Add(server.ServerName);
+
+                yield return (uid, server);
             }
-
-            return list;
-        }
-
-        /// <summary>
-        /// backmen change: Gets the ids of all the servers from a specified map.
-        /// </summary>
-        public IEnumerable<int> GetAvailableServerIds(MapId mapId)
-        {
-            var allServers = EntityQueryEnumerator<ResearchServerComponent, TransformComponent>();
-            var list = new List<int>();
-
-            while (allServers.MoveNext(out var server, out var xform))
-            {
-                // backmen edit: RnD servers are local for a map
-                if (xform.MapID != mapId)
-                    continue;
-                // backmen edit end
-
-                list.Add(server.Id);
-            }
-
-            return list;
         }
         // backmen changes end
 

--- a/Content.Server/Research/Systems/ResearchSystem.cs
+++ b/Content.Server/Research/Systems/ResearchSystem.cs
@@ -48,11 +48,11 @@ namespace Content.Server.Research.Systems
             serverUid = null;
             serverComponent = null;
 
-            var query = EntityQueryEnumerator<ResearchServerComponent>();
-            while (query.MoveNext(out var uid, out var server))
+            var query = EntityQueryEnumerator<ResearchServerComponent, TransformComponent>();
+            while (query.MoveNext(out var uid, out var server, out var xform))
             {
                 // backmen edit: RnD servers are local for a map
-                if (Transform(uid).MapID != mapId)
+                if (xform.MapID != mapId)
                     continue;
                 // backmen edit end
 
@@ -105,44 +105,43 @@ namespace Content.Server.Research.Systems
         /// <summary>
         /// Gets the names of all the servers.
         /// </summary>
-        /// <returns></returns>
-        public string[] GetAvailableServerNames(MapId mapId)
+        public IEnumerable<string> GetAvailableServerNames(MapId mapId)
         {
-            var allServers = EntityQueryEnumerator<ResearchServerComponent>();
+            var allServers = EntityQueryEnumerator<ResearchServerComponent, TransformComponent>();
             var list = new List<string>();
 
-            while (allServers.MoveNext(out var serverUid, out var server))
+            while (allServers.MoveNext(out var server, out var xform))
             {
                 // backmen edit: RnD servers are local for a map
-                if (Transform(serverUid).MapID != mapId)
+                if (xform.MapID != mapId)
                     continue;
                 // backmen edit end
 
                 list.Add(server.ServerName);
             }
 
-            return list.ToArray();
+            return list;
         }
 
         /// <summary>
         /// backmen change: Gets the ids of all the servers from a specified map.
         /// </summary>
-        public int[] GetAvailableServerIds(MapId mapId)
+        public IEnumerable<int> GetAvailableServerIds(MapId mapId)
         {
-            var allServers = EntityQueryEnumerator<ResearchServerComponent>();
+            var allServers = EntityQueryEnumerator<ResearchServerComponent, TransformComponent>();
             var list = new List<int>();
 
-            while (allServers.MoveNext(out var serverUid, out var server))
+            while (allServers.MoveNext(out var server, out var xform))
             {
                 // backmen edit: RnD servers are local for a map
-                if (Transform(serverUid).MapID != mapId)
+                if (xform.MapID != mapId)
                     continue;
                 // backmen edit end
 
                 list.Add(server.Id);
             }
 
-            return list.ToArray();
+            return list;
         }
         // backmen changes end
 


### PR DESCRIPTION

**Изменения**

:cl: Rouden
- tweak: Теперь сервера РнД локальны для каждой карты. Лаваленд и станция больше не могут соединяться друг с дргом.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Новые возможности**
  - Выбор серверов теперь учитывает текущую карту, что гарантирует отображение только серверов, актуальных для вашей игровой области.
  - Интерфейс был обновлён для фильтрации серверов по локации, благодаря чему процесс подключения стал интуитивнее и надёжнее.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->