### PR TITLE
[Fix] Virologist Back Loadout Fix

### DIFF
--- a/Resources/Prototypes/_Backmen/Loadouts/Jobs/Medical/virologist.yml
+++ b/Resources/Prototypes/_Backmen/Loadouts/Jobs/Medical/virologist.yml
@@ -13,17 +13,17 @@
 - type: loadout
   id: VirologistBackpack
   equipment:
-    back: ClothingBackpackMedical
+    back: ClothingBackpackVirology
 
 - type: loadout
   id: VirologistSatchel
   equipment:
-    back: ClothingBackpackSatchelMedical
+    back: ClothingBackpackSatchelVirology
 
 - type: loadout
   id: VirologistDuffel
   equipment:
-    back: ClothingBackpackDuffelMedical
+    back: ClothingBackpackDuffelVirology
 
 #OuterClothing
 - type: loadout


### PR DESCRIPTION
# Описание PR
Возвращает сумки и рюкзаки вирусолога в лодаут вирусологу

## Тип PR
- [x] Fix

:cl: 
- fix: Исправлено отсутствие сумок и рюкзаков вирусолога в соответствующем лодауте.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Рефактор**
	- Обновлены обозначения снаряжения для роли вирусолога: новые наименования для рюкзака, сумки и чемодана теперь чётко передают тематику вирусологии.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->