### PR TITLE
[Fix] Centcom Private Officer Ammunition Fix

### DIFF
--- a/Resources/Prototypes/_Backmen/Roles/Jobs/CentCom/private_officer.yml
+++ b/Resources/Prototypes/_Backmen/Roles/Jobs/CentCom/private_officer.yml
@@ -68,7 +68,8 @@
     back:
     - MedkitCombatFilled
     - BoxSurvivalSecurity
-    - MagazineRifle
+    - MagazineRifleFamas556UEG
+    - MagazinePistol9x17
   #innerClothingSkirt: ClothingUniformJumpskirtSec
   #satchel: ClothingBackpackSatchelSecurityFilled
   #duffelbag: ClothingBackpackDuffelSecurityFilled


### PR DESCRIPTION
# Описание PR
В рюкзак приватному офицеру СБ ЦК добавлены соответствующие патроны для FAMAS и служебного пистолета.

## Тип PR
- [x] Fix

:cl: 
- fix: У ПОСБЦК теперь есть соответствующие боеприпасы.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Новые возможности**
  - Обновлена экипировка для одной из игровых ролей, влияющая на выбор боеприпасов.
  - Стандартный вариант магазина для винтовки заменён на специализированный, а также добавлен новый магазин для пистолета.
  - Эти улучшения позволяют более точно настроить арсенал, что может положительно сказаться на игровом опыте.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->