### PR TITLE
[Fix] Hristov Epileptic's Dream Fix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -74,10 +74,10 @@
       - CartridgeAntiMateriel
     capacity: 5
     proto: CartridgeAntiMateriel
-  - type: SpeedModifiedOnWield
-    walkModifier: 0.25
-    sprintModifier: 0.25
-  - type: CursorOffsetRequiresWield
+#  - type: SpeedModifiedOnWield
+#    walkModifier: 0.25
+#    sprintModifier: 0.25
+#  - type: CursorOffsetRequiresWield
 #  - type: EyeCursorOffset
 #    maxOffset: 3
 #    pvsIncrease: 0.3


### PR DESCRIPTION
# Описание PR
В прототипе христова были закомментированы компоненты CursorOffsetRequiresWield и SpeedModifiedOnWield. Теперь камеру не трясёт при прицеливании. Ну и не понятно зачем добавленный синдром горы при двуручном хвате так же был убран.

## Тип PR
- [x] Fix

:cl: 
- fix: При взятии христова в две руки камера больше не создаёт сон эпилептика.
- tweak: Теперь у христова нет колоссального замедления при взятии в две руки.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Отключены некоторые настройки, влияющие на скорость перемещения и позиционирование прицеливания при использовании снайперского оружия, что может привести к изменённой динамике его работы.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->