### PR TITLE
[Fix] Centcomm Cargo Fix

### DIFF
--- a/Resources/Maps/Backmen/backmen_centcom.yml
+++ b/Resources/Maps/Backmen/backmen_centcom.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 249.0.0
+  engineVersion: 251.0.0
   forkId: backmen
-  forkVersion: a96b23cfabffc3c0967935817d77d76f37ad889d
-  time: 03/30/2025 13:33:18
-  entityCount: 10813
+  forkVersion: 8c1b3a60ecabe677da7b65ab06b93ae2faeb8fe0
+  time: 04/15/2025 12:26:51
+  entityCount: 10808
 maps:
 - 6696
 grids:
@@ -172,7 +172,7 @@ entities:
           version: 6
         3,3:
           ind: 3,3
-          tiles: kwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAJAAAAAAAJAAAAAAAJAAAAAAAkwAAAAAAIQAAAAAAKAAAAAAAIQAAAAAAkwAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAkwAAAAAAIQAAAAAAKAAAAAAAIQAAAAAAkwAAAAAAKAAAAAAAKAAAAAAALwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAFgAAAAAAAQAAAAAAkwAAAAAAIQAAAAAAKAAAAAAAIQAAAAAAkwAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAFgAAAAAAAQAAAAAAkwAAAAAAIQAAAAAAKAAAAAAAIQAAAAAAkwAAAAAAKAAAAAAAKAAAAAAALwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAFgAAAAAAAQAAAAAAkwAAAAAAHwAAAAAAkwAAAAAAHwAAAAAAkwAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAkwAAAAAAKAAAAAAAKAAAAAAALwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAkwAAAAAAkwAAAAAAKAAAAAAAKAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAkwAAAAAALwAAAAAALwAAAAAABAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAFgAAAAAAFgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAwAAAAAAAQAAAAAAFgAAAAAAFgAAAAAAFgAAAAAAFgAAAAAAAQAAAAAAAQAAAAAAHwAAAAAAFgAAAAAAFgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAAQAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAFgAAAAAAFgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAJQAAAAAAAwAAAAAAAwAAAAAABAAAAAAAAQAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAAQAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAkwAAAAAALgAAAAAALgAAAAAALgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAFAAAAAAAFgAAAAAAFgAAAAAAFAAAAAAAkwAAAAAAkwAAAAAALgAAAAAALgAAAAAALgAAAAAAAwAAAAAAFAAAAAAAFAAAAAAAkwAAAAAAEQAAAAAAEQAAAAAAEQAAAAAAEgAAAAAAJwAAAAAAJwAAAAAAHQAAAAAAHQAAAAAAkwAAAAAALgAAAAAALgAAAAAALgAAAAAAFAAAAAAAFAAAAAAAEgAAAAAAEgAAAAAAEgAAAAAAEgAAAAAAEgAAAAAAEgAAAAAAJwAAAAAAJwAAAAAAHQAAAAAAHQAAAAAAkwAAAAAAkwAAAAAALgAAAAAAkwAAAAAA
+          tiles: kwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAJAAAAAAAJAAAAAAAJAAAAAAAkwAAAAAAIQAAAAAAKAAAAAAAIQAAAAAAkwAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAkwAAAAAAIQAAAAAAKAAAAAAAIQAAAAAAkwAAAAAAKAAAAAAAKAAAAAAAkwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAFgAAAAAAAQAAAAAAkwAAAAAAIQAAAAAAKAAAAAAAIQAAAAAAkwAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAFgAAAAAAAQAAAAAAkwAAAAAAIQAAAAAAKAAAAAAAIQAAAAAAkwAAAAAAKAAAAAAAKAAAAAAAkwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAFgAAAAAAAQAAAAAAkwAAAAAAHwAAAAAAkwAAAAAAHwAAAAAAkwAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAkwAAAAAAKAAAAAAAKAAAAAAAkwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAkwAAAAAAkwAAAAAAKAAAAAAAKAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAkwAAAAAALwAAAAAALwAAAAAABAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAFgAAAAAAFgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAwAAAAAAAQAAAAAAFgAAAAAAFgAAAAAAFgAAAAAAFgAAAAAAAQAAAAAAAQAAAAAAHwAAAAAAFgAAAAAAFgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAAQAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAFgAAAAAAFgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAJQAAAAAAAwAAAAAAAwAAAAAABAAAAAAAAQAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAAQAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAkwAAAAAALgAAAAAALgAAAAAALgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAFAAAAAAAFgAAAAAAFgAAAAAAFAAAAAAAkwAAAAAAkwAAAAAALgAAAAAALgAAAAAALgAAAAAAAwAAAAAAFAAAAAAAFAAAAAAAkwAAAAAAEQAAAAAAEQAAAAAAEQAAAAAAEgAAAAAAJwAAAAAAJwAAAAAAHQAAAAAAHQAAAAAAkwAAAAAALgAAAAAALgAAAAAALgAAAAAAFAAAAAAAFAAAAAAAEgAAAAAAEgAAAAAAEgAAAAAAEgAAAAAAEgAAAAAAEgAAAAAAJwAAAAAAJwAAAAAAHQAAAAAAHQAAAAAAkwAAAAAAkwAAAAAALgAAAAAAkwAAAAAA
           version: 6
         3,2:
           ind: 3,2
@@ -200,7 +200,7 @@ entities:
           version: 6
         4,3:
           ind: 4,3
-          tiles: KAAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAkwAAAAAAAQAAAAAAFgAAAAAAFgAAAAAAAQAAAAAAKwAAAAAAKwAAAAAAKwAAAAAAKwAAAAAAKwAAAAAAkwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAKAAAAAAAkwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAKwAAAAAAKwAAAAAAKwAAAAAAkwAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAkwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAkwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAKAAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAADwAAAAAAkwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAkwAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAkwAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAAkwAAAAAAAQAAAAAAFgAAAAAAFgAAAAAAAQAAAAAAMAAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAKAAAAAAAkwAAAAAADwAAAAAAKgAAAAAAKgAAAAAADwAAAAAAkwAAAAAAAQAAAAAAFgAAAAAAFgAAAAAAAQAAAAAAkwAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAkwAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAAkwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAMAAAAAAALwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAFgAAAAAAAQAAAAAAFgAAAAAAHwAAAAAAFgAAAAAAFgAAAAAAFgAAAAAAHwAAAAAAFgAAAAAAFgAAAAAAFgAAAAAAHwAAAAAAFgAAAAAAFgAAAAAAFgAAAAAAHwAAAAAAGwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAFgAAAAAAAQAAAAAAkwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAkwAAAAAAFgAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAFgAAAAAAkwAAAAAAJwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAIAAAAAAAkwAAAAAAIAAAAAAAkwAAAAAAFgAAAAAAFgAAAAAAFgAAAAAAFgAAAAAAFgAAAAAAFgAAAAAAFgAAAAAAkwAAAAAAJwAAAAAALgAAAAAALgAAAAAAkwAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAJwAAAAAALgAAAAAALgAAAAAAkwAAAAAAIAAAAAAAkwAAAAAAIAAAAAAAkwAAAAAADQAAAAAADQAAAAAADQAAAAAADQAAAAAADQAAAAAADQAAAAAADQAAAAAAkwAAAAAAJwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAIAAAAAAAGwAAAAAAIAAAAAAAkwAAAAAADQAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAADQAAAAAAkwAAAAAAHQAAAAAA
+          tiles: KAAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAkwAAAAAAAQAAAAAAFgAAAAAAFgAAAAAAAQAAAAAAKwAAAAAAKwAAAAAAKwAAAAAAKwAAAAAAKwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAKAAAAAAAkwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAKwAAAAAAKwAAAAAAKwAAAAAAkwAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAkwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAKAAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAADwAAAAAAkwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAkwAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAkwAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAAkwAAAAAAAQAAAAAAFgAAAAAAFgAAAAAAAQAAAAAAMAAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAKAAAAAAAkwAAAAAADwAAAAAAKgAAAAAAKgAAAAAADwAAAAAAkwAAAAAAAQAAAAAAFgAAAAAAFgAAAAAAAQAAAAAAkwAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAkwAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAAkwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAMAAAAAAALwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAFgAAAAAAAQAAAAAAFgAAAAAAHwAAAAAAFgAAAAAAFgAAAAAAFgAAAAAAHwAAAAAAFgAAAAAAFgAAAAAAFgAAAAAAHwAAAAAAFgAAAAAAFgAAAAAAFgAAAAAAHwAAAAAAGwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAFgAAAAAAAQAAAAAAkwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAkwAAAAAAFgAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAFgAAAAAAkwAAAAAAJwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAIAAAAAAAkwAAAAAAIAAAAAAAkwAAAAAAFgAAAAAAFgAAAAAAFgAAAAAAFgAAAAAAFgAAAAAAFgAAAAAAFgAAAAAAkwAAAAAAJwAAAAAALgAAAAAALgAAAAAAkwAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAJwAAAAAALgAAAAAALgAAAAAAkwAAAAAAIAAAAAAAkwAAAAAAIAAAAAAAkwAAAAAADQAAAAAADQAAAAAADQAAAAAADQAAAAAADQAAAAAADQAAAAAADQAAAAAAkwAAAAAAJwAAAAAAkwAAAAAAkwAAAAAAkwAAAAAAIAAAAAAAGwAAAAAAIAAAAAAAkwAAAAAADQAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAADQAAAAAAkwAAAAAAHQAAAAAA
           version: 6
         4,2:
           ind: 4,2
@@ -9894,6 +9894,17 @@ entities:
     - type: NavMap
     - type: BecomesStation
       id: centcomm
+    - type: StationCargoBountyDatabase
+      checkedBounties: []
+      history: []
+      bounties: []
+    - type: StationCargoOrderDatabase
+      orders: []
+    - type: StationCargoShuttle
+      path: /Maps/Shuttles/cargo.yml
+    - type: StationBankAccount
+    - type: TradeStation
+    - type: CargoDeliveryData
   - uid: 6696
     components:
     - type: MetaData
@@ -11645,7 +11656,7 @@ entities:
       pos: 16.5,75.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -103490.31
+      secondsUntilStateChange: -105361.63
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11718,18 +11729,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 53.5,94.5
-      parent: 1
-- proto: AirlockCargoGlassLocked
-  entities:
-  - uid: 110
-    components:
-    - type: Transform
-      pos: 59.5,52.5
-      parent: 1
-  - uid: 111
-    components:
-    - type: Transform
-      pos: 57.5,52.5
       parent: 1
 - proto: AirlockCargoLocked
   entities:
@@ -11819,6 +11818,26 @@ entities:
       parent: 1
 - proto: AirlockCentralCommandGlassLocked
   entities:
+  - uid: 110
+    components:
+    - type: Transform
+      pos: 57.5,52.5
+      parent: 1
+    - type: Tag
+      tags:
+      - GlassAirlock
+      - EmagImmune
+    - type: ArrivalsProtect
+  - uid: 111
+    components:
+    - type: Transform
+      pos: 59.5,52.5
+      parent: 1
+    - type: Tag
+      tags:
+      - GlassAirlock
+      - EmagImmune
+    - type: ArrivalsProtect
   - uid: 117
     components:
     - type: Transform
@@ -11848,7 +11867,7 @@ entities:
       pos: 68.5,79.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -105675.875
+      secondsUntilStateChange: -107547.195
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -26200,6 +26219,83 @@ entities:
     - type: Transform
       pos: 82.5,54.5
       parent: 1
+- proto: CargoPalletBuy
+  entities:
+  - uid: 2808
+    components:
+    - type: Transform
+      pos: 64.5,53.5
+      parent: 1
+  - uid: 2815
+    components:
+    - type: Transform
+      pos: 63.5,53.5
+      parent: 1
+  - uid: 2816
+    components:
+    - type: Transform
+      pos: 66.5,53.5
+      parent: 1
+  - uid: 2817
+    components:
+    - type: Transform
+      pos: 67.5,53.5
+      parent: 1
+  - uid: 2818
+    components:
+    - type: Transform
+      pos: 65.5,53.5
+      parent: 1
+  - uid: 2819
+    components:
+    - type: Transform
+      pos: 63.5,51.5
+      parent: 1
+  - uid: 2820
+    components:
+    - type: Transform
+      pos: 65.5,51.5
+      parent: 1
+  - uid: 2821
+    components:
+    - type: Transform
+      pos: 67.5,51.5
+      parent: 1
+  - uid: 2822
+    components:
+    - type: Transform
+      pos: 66.5,51.5
+      parent: 1
+  - uid: 2823
+    components:
+    - type: Transform
+      pos: 64.5,51.5
+      parent: 1
+  - uid: 2824
+    components:
+    - type: Transform
+      pos: 63.5,49.5
+      parent: 1
+  - uid: 2825
+    components:
+    - type: Transform
+      pos: 65.5,49.5
+      parent: 1
+  - uid: 2826
+    components:
+    - type: Transform
+      pos: 64.5,49.5
+      parent: 1
+  - uid: 2827
+    components:
+    - type: Transform
+      pos: 67.5,49.5
+      parent: 1
+  - uid: 2828
+    components:
+    - type: Transform
+      pos: 66.5,49.5
+      parent: 1
 - proto: CargoPalletSell
   entities:
   - uid: 2684
@@ -26955,11 +27051,6 @@ entities:
     - type: Transform
       pos: 22.5,52.5
       parent: 1
-  - uid: 2808
-    components:
-    - type: Transform
-      pos: 63.5,53.5
-      parent: 1
   - uid: 2809
     components:
     - type: Transform
@@ -26989,76 +27080,6 @@ entities:
     components:
     - type: Transform
       pos: 63.5,55.5
-      parent: 1
-  - uid: 2815
-    components:
-    - type: Transform
-      pos: 65.5,53.5
-      parent: 1
-  - uid: 2816
-    components:
-    - type: Transform
-      pos: 66.5,53.5
-      parent: 1
-  - uid: 2817
-    components:
-    - type: Transform
-      pos: 67.5,53.5
-      parent: 1
-  - uid: 2818
-    components:
-    - type: Transform
-      pos: 64.5,53.5
-      parent: 1
-  - uid: 2819
-    components:
-    - type: Transform
-      pos: 63.5,51.5
-      parent: 1
-  - uid: 2820
-    components:
-    - type: Transform
-      pos: 65.5,51.5
-      parent: 1
-  - uid: 2821
-    components:
-    - type: Transform
-      pos: 66.5,51.5
-      parent: 1
-  - uid: 2822
-    components:
-    - type: Transform
-      pos: 67.5,51.5
-      parent: 1
-  - uid: 2823
-    components:
-    - type: Transform
-      pos: 64.5,51.5
-      parent: 1
-  - uid: 2824
-    components:
-    - type: Transform
-      pos: 63.5,49.5
-      parent: 1
-  - uid: 2825
-    components:
-    - type: Transform
-      pos: 65.5,49.5
-      parent: 1
-  - uid: 2826
-    components:
-    - type: Transform
-      pos: 64.5,49.5
-      parent: 1
-  - uid: 2827
-    components:
-    - type: Transform
-      pos: 67.5,49.5
-      parent: 1
-  - uid: 2828
-    components:
-    - type: Transform
-      pos: 66.5,49.5
       parent: 1
   - uid: 2829
     components:
@@ -28371,6 +28392,59 @@ entities:
     components:
     - type: Transform
       pos: 44.5,98.5
+      parent: 1
+- proto: ChemistryBottleEpinephrine
+  entities:
+  - uid: 4147
+    components:
+    - type: Transform
+      pos: 45.67016,95.74208
+      parent: 1
+  - uid: 4148
+    components:
+    - type: Transform
+      pos: 17.626833,66.8925
+      parent: 1
+- proto: ChemistryBottleEthanol
+  entities:
+  - uid: 4149
+    components:
+    - type: MetaData
+      name: бутылочка (дезинфицирующие средство)
+    - type: Transform
+      pos: 18.757507,62.85744
+      parent: 1
+- proto: ChemistryBottleOmnizine
+  entities:
+  - uid: 6843
+    components:
+    - type: Transform
+      pos: 11.283588,70.070724
+      parent: 1
+  - uid: 6844
+    components:
+    - type: Transform
+      pos: 11.542847,70.070724
+      parent: 1
+- proto: ChemistryBottleRobustHarvest
+  entities:
+  - uid: 7927
+    components:
+    - type: Transform
+      pos: 31.223812,79.64735
+      parent: 1
+  - uid: 7928
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 29.386095,78.220505
+      parent: 1
+- proto: ChemistryBottleUnstableMutagen
+  entities:
+  - uid: 8668
+    components:
+    - type: Transform
+      pos: 31.223812,79.83219
       parent: 1
 - proto: ChemistryHotplate
   entities:
@@ -31142,6 +31216,7 @@ entities:
     - type: Transform
       pos: 84.5,49.5
       parent: 1
+    - type: Conveyed
   - uid: 3412
     components:
     - type: Transform
@@ -31475,7 +31550,7 @@ entities:
       pos: 1.5,62.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -106080.74
+      secondsUntilStateChange: -107952.06
       state: Opening
   - uid: 3463
     components:
@@ -36058,27 +36133,6 @@ entities:
       parent: 4142
     - type: Physics
       canCollide: False
-- proto: ChemistryBottleEpinephrine
-  entities:
-  - uid: 4147
-    components:
-    - type: Transform
-      pos: 45.67016,95.74208
-      parent: 1
-  - uid: 4148
-    components:
-    - type: Transform
-      pos: 17.626833,66.8925
-      parent: 1
-- proto: EthanolChemistryBottle
-  entities:
-  - uid: 4149
-    components:
-    - type: MetaData
-      name: бутылочка (дезинфицирующие средство)
-    - type: Transform
-      pos: 18.757507,62.85744
-      parent: 1
 - proto: ExtinguisherCabinetFilled
   entities:
   - uid: 4150
@@ -39372,6 +39426,9 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 12.426975,84.6819
       parent: 1
+    - type: CollisionWake
+      enabled: False
+    - type: Conveyed
 - proto: FoodPlateTin
   entities:
   - uid: 4450
@@ -59534,18 +59591,6 @@ entities:
     - type: Transform
       pos: 90.5,58.5
       parent: 1
-- proto: ChemistryBottleOmnizine
-  entities:
-  - uid: 6843
-    components:
-    - type: Transform
-      pos: 11.283588,70.070724
-      parent: 1
-  - uid: 6844
-    components:
-    - type: Transform
-      pos: 11.542847,70.070724
-      parent: 1
 - proto: OperatingTable
   entities:
   - uid: 6845
@@ -66190,19 +66235,6 @@ entities:
     - type: Transform
       pos: 81.49663,63.5843
       parent: 1
-- proto: ChemistryBottleRobustHarvest
-  entities:
-  - uid: 7927
-    components:
-    - type: Transform
-      pos: 31.223812,79.64735
-      parent: 1
-  - uid: 7928
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 29.386095,78.220505
-      parent: 1
 - proto: RubberStampApproved
   entities:
   - uid: 7929
@@ -66384,6 +66416,9 @@ entities:
     - type: Transform
       pos: 13.108704,85.61782
       parent: 1
+    - type: CollisionWake
+      enabled: False
+    - type: Conveyed
 - proto: ScrapCamera
   entities:
   - uid: 7956
@@ -66416,6 +66451,9 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 13.783791,85.411285
       parent: 1
+    - type: CollisionWake
+      enabled: False
+    - type: Conveyed
 - proto: ScrapIntercom
   entities:
   - uid: 7960
@@ -66432,6 +66470,9 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 12.361916,85.11441
       parent: 1
+    - type: CollisionWake
+      enabled: False
+    - type: Conveyed
 - proto: ScrapPAI
   entities:
   - uid: 7962
@@ -66440,6 +66481,9 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 12.658791,84.77066
       parent: 1
+    - type: CollisionWake
+      enabled: False
+    - type: Conveyed
 - proto: ScrapSteel
   entities:
   - uid: 7963
@@ -66476,12 +66520,14 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 12.84885,84.791275
       parent: 1
+    - type: Conveyed
   - uid: 7970
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 12.614475,84.353775
       parent: 1
+    - type: Conveyed
 - proto: ShardGlassReinforced
   entities:
   - uid: 7971
@@ -66489,6 +66535,7 @@ entities:
     - type: Transform
       pos: 12.28635,84.5569
       parent: 1
+    - type: Conveyed
 - proto: SheetGlass
   entities:
   - uid: 1720
@@ -66577,6 +66624,9 @@ entities:
     - type: Transform
       pos: 14.778152,87.332825
       parent: 1
+    - type: CollisionWake
+      enabled: False
+    - type: Conveyed
 - proto: SheetRGlass
   entities:
   - uid: 1724
@@ -66664,6 +66714,9 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 14.690041,87.67691
       parent: 1
+    - type: CollisionWake
+      enabled: False
+    - type: Conveyed
 - proto: SheetSteel10
   entities:
   - uid: 7985
@@ -66803,41 +66856,6 @@ entities:
           - 6793
           - 6790
           - 6794
-- proto: ShippingContainerCybersun
-  entities:
-  - uid: 7986
-    components:
-    - type: Transform
-      pos: 66.5,54.5
-      parent: 1
-- proto: ShippingContainerDonkCo
-  entities:
-  - uid: 7987
-    components:
-    - type: Transform
-      pos: 65.5,53.5
-      parent: 1
-- proto: ShippingContainerGorlex
-  entities:
-  - uid: 7988
-    components:
-    - type: Transform
-      pos: 66.5,51.5
-      parent: 1
-- proto: ShippingContainerGorlexRed
-  entities:
-  - uid: 7989
-    components:
-    - type: Transform
-      pos: 67.5,50.5
-      parent: 1
-- proto: ShippingContainerInterdyne
-  entities:
-  - uid: 7990
-    components:
-    - type: Transform
-      pos: 64.5,50.5
-      parent: 1
 - proto: Shovel
   entities:
   - uid: 7991
@@ -66854,18 +66872,21 @@ entities:
       rot: 3.141592653589793 rad
       pos: 64.5,55.5
       parent: 1
+    - type: ArrivalsProtect
   - uid: 7993
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 62.5,55.5
       parent: 1
+    - type: ArrivalsProtect
   - uid: 7994
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 63.5,55.5
       parent: 1
+    - type: ArrivalsProtect
   - uid: 7995
     components:
     - type: Transform
@@ -71356,11 +71377,13 @@ entities:
     - type: Transform
       pos: 66.5,87.5
       parent: 1
+    - type: Conveyed
   - uid: 10307
     components:
     - type: Transform
       pos: 65.5,87.5
       parent: 1
+    - type: Conveyed
 - proto: TelecomServerFilled
   entities:
   - uid: 8635
@@ -71932,13 +71955,6 @@ entities:
     components:
     - type: Transform
       pos: 72.5,62.5
-      parent: 1
-- proto: ChemistryBottleUnstableMutagen
-  entities:
-  - uid: 8668
-    components:
-    - type: Transform
-      pos: 31.223812,79.83219
       parent: 1
 - proto: UprightPianoInstrument
   entities:

--- a/Resources/Prototypes/Entities/Stations/nanotrasen.yml
+++ b/Resources/Prototypes/Entities/Stations/nanotrasen.yml
@@ -38,10 +38,10 @@
     - BaseStation
     - BaseStationAlertLevels
     - BaseStationNanotrasen
-  #  - BaseStationCargo #Backmen
+    - BkmCCBaseStationCargo #Backmen
     - BaseStationJobsSpawning #Backmen
     - BaseStationRecords #Backmen
-  #  - BaseStationShuttles #Backmen
+    - BkmCCBaseStationShuttles #Backmen
     - BaseStationExpeditions #Backmen
     - BaseStationMagnet #Backmen
   categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/_Backmen/Entities/Stations/base.yml
+++ b/Resources/Prototypes/_Backmen/Entities/Stations/base.yml
@@ -1,0 +1,16 @@
+- type: entity
+  id: BkmCCBaseStationShuttles
+  abstract: true
+  components:
+    - type: StationCargoShuttle
+      path: /Maps/Shuttles/cargo.yml
+
+- type: entity
+  id: BkmCCBaseStationCargo
+  abstract: true
+  components:
+    - type: StationBankAccount
+      balance: 75000
+    - type: StationCargoOrderDatabase
+    - type: StationCargoBountyDatabase
+    - type: TradeStation


### PR DESCRIPTION
# Описание PR
Ну значит, подшаманил я с компонентами немного и теперь карго ЦК нормально работает.

## Тип PR
- [x] Fix

:cl: 
- tweak: Теперь на станции ЦК есть встроенный трейд пост.
- fix: Карго ЦК снова функционирует.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Новые возможности**
	- Добавлены новые объекты и компоненты для управления грузом, банковскими счетами станции и торговлей на Центральной Командной станции.
	- Введён новый объект для покупки грузовых паллет и перемещены некоторые химические бутылки на карте.
- **Исправления**
	- Восстановлены защищённые стеклянные шлюзы с дополнительными тегами и защитой.
	- Перемещены и обновлены компоненты некоторых объектов для улучшения взаимодействия и защиты.
- **Рефакторинг**
	- Обновлены базовые шаблоны станций для использования новых компонентов управления грузом и шаттлами.
- **Обслуживание**
	- Удалены устаревшие грузовые контейнеры и обновлены метаданные карты.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->