### PR TITLE
hotfix

### DIFF
--- a/Content.Server/Backmen/Shipwrecked/ShipwreckedRuleSystem.cs
+++ b/Content.Server/Backmen/Shipwrecked/ShipwreckedRuleSystem.cs
@@ -583,26 +583,31 @@ public sealed class ShipwreckedRuleSystem : GameRuleSystem<ShipwreckedRuleCompon
             var point = direction * distance;
 
             var dungeonProto = structuresToBuild.Pop();
+            List<Dungeon> dungeon = new();
             try
             {
-                var dungeon = await _dungeonSystem.GenerateDungeonAsync(dungeonProto,
+                dungeon = await _dungeonSystem.GenerateDungeonAsync(dungeonProto,
                     component.PlanetMap.Value,
                     component.PlanetGrid,
                     point,
                     _random.Next());
 
-                component.Structures.AddRange(dungeon);
-                foreach (var dungeon1 in dungeon)
-                {
-                    foreach (var tile in dungeon1.AllTiles)
-                    {
-                        _roofSystem.SetRoof(gridRoof, tile, true);
-                    }
-                }
             }
             catch (Exception e)
             {
                 Log.Error(e.ToString());
+            }
+
+            if(dungeon.Count == 0)
+                continue;
+
+            component.Structures.AddRange(dungeon);
+            foreach (var dungeon1 in dungeon)
+            {
+                foreach (var tile in dungeon1.AllTiles)
+                {
+                    _roofSystem.SetRoof(gridRoof, tile, true);
+                }
             }
         }
     }

--- a/Content.Server/Procedural/DungeonSystem.Helpers.cs
+++ b/Content.Server/Procedural/DungeonSystem.Helpers.cs
@@ -45,6 +45,9 @@ public sealed partial class DungeonSystem
 
             foreach (var node in forest)
             {
+                if(!connections.ContainsKey(node))
+                    continue;
+
                 foreach (var conn in connections[node])
                 {
                     // Existing tile, skip

--- a/Content.Shared/Backmen/Surgery/Traumas/Systems/TraumaSystem.Organs.cs
+++ b/Content.Shared/Backmen/Surgery/Traumas/Systems/TraumaSystem.Organs.cs
@@ -133,7 +133,8 @@ public partial class TraumaSystem
         if (!Resolve(uid, ref organ))
             return false;
 
-        organ.IntegrityModifiers.Add((identifier, effectOwner), severity);
+        if(!organ.IntegrityModifiers.TryAdd((identifier, effectOwner), severity))
+            return false;
         UpdateOrganIntegrity(uid, organ);
 
         return true;

--- a/Content.Shared/Backmen/Surgery/Traumas/Systems/TraumaSystem.Process.cs
+++ b/Content.Shared/Backmen/Surgery/Traumas/Systems/TraumaSystem.Process.cs
@@ -487,6 +487,8 @@ public partial class TraumaSystem
         // organ damage is like, very deadly, but not yet
         // so like, like, yeah, we don't want a disabler to induce some EVIL ASS organ damage with a 0,000001% chance and ruin your round
         // Very unlikely to happen if your woundables are in a good condition
+        if(target.Comp.WoundableIntegrity <= 0)
+            return false;
         var chance =
             FixedPoint2.Clamp(
                 target.Comp.IntegrityCap / target.Comp.WoundableIntegrity / totalIntegrity

--- a/Resources/Prototypes/_Backmen/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Backmen/GameRules/roundstart.yml
@@ -176,7 +176,7 @@
         - FrozenWastes
         - Jungle
         - Continental
-        - Lava
+        #- Lava
         - RuinedMegacity
       spawnPointHecate: SpawnPointShipwreckHecate
       hecatePrototype: MobQuestHecateShipwrecked

--- a/Resources/Prototypes/_Backmen/Procedural/Shipwreck/shipwreck_destinations.yml
+++ b/Resources/Prototypes/_Backmen/Procedural/Shipwreck/shipwreck_destinations.yml
@@ -36,7 +36,7 @@
   components:
   - type: MapLight
     # Цвет солнечного света: тёплый рассветный (очень тёмный оранжево‑красный)
-    ambientLightColor: "#030101"
+    ambientLightColor: "#FFFFE0"
   - type: LightCycle
     duration: 720            # секундами
     offset:   0
@@ -69,7 +69,7 @@
   components:
   - type: MapLight
     # Цвет солнечного света: густой полуденный зелёно‑желтый отблеск сквозь листву
-    ambientLightColor: "#010301"
+    ambientLightColor: "#DFFF00"
   - type: LightCycle
     duration: 720
     offset:   0


### PR DESCRIPTION

:cl: 
- remove: Убрана лава из крушения
- tweak: В крушение поменялся цвет солнца в пустыне и в джунглях
- tweak: Исправлены некоторые ошибки в травмах


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Исправления ошибок**
  - Улучшена обработка ошибок при генерации и добавлении структур в процедурных событиях, предотвращая сбои при отсутствии данных.
  - Добавлена проверка наличия соединений в алгоритме минимального остовного дерева, чтобы избежать ошибок при отсутствии ключей.
  - Исправлено поведение добавления модификаторов урона органам, предотвращая исключения при повторном добавлении.
  - Добавлена проверка целостности перед расчетом вероятности травмы органа, предотвращая некорректные вычисления.

- **Изменения оформления**
  - Обновлены цвета окружающего освещения для биомов "Пустынные пустоши" и "Джунгли" для более яркой и заметной визуализации.
  - Отключена возможность выбора "Лавы" как пункта назначения в настройках правил Shipwrecked (оставлено в комментарии).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->