### PR TITLE
tweak barotrauma

### DIFF
--- a/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
@@ -32,7 +32,7 @@ namespace Content.Server.Atmos.EntitySystems
         private float _timer;
 
         private bool _barotraumaEnabled = true; // Backmen edit
-
+        private EntityQuery<ConsciousnessComponent>  _consciousnessQuery; // Backmen edit
         public override void Initialize()
         {
             SubscribeLocalEvent<PressureProtectionComponent, GotEquippedEvent>(OnPressureProtectionEquipped);
@@ -44,6 +44,7 @@ namespace Content.Server.Atmos.EntitySystems
             SubscribeLocalEvent<PressureImmunityComponent, ComponentRemove>(OnPressureImmuneRemove);
 
             Subs.CVar(_cfg, CCVars.GameBarotraumaEnabled, value => _barotraumaEnabled = value, true); // Backmen edit
+            _consciousnessQuery = GetEntityQuery<ConsciousnessComponent>(); // Backmen edit
         }
 
         private void OnPressureImmuneInit(EntityUid uid, PressureImmunityComponent pressureImmunity, ComponentInit args)
@@ -237,11 +238,12 @@ namespace Content.Server.Atmos.EntitySystems
                     totalDamage += damage;
                 }
 
-                // backmen edit: Consciousness woundable damage check
-                if (HasComp<ConsciousnessComponent>(uid))
+                //start-backmen edit: Consciousness woundable damage check
+                if (_consciousnessQuery.HasComp(uid))
                 {
                     totalDamage = _wounds.GetBodySeverityPoint(uid);
                 }
+                //end-backmen edit: Consciousness woundable damage check
 
                 if (totalDamage >= barotrauma.MaxDamage)
                     continue;

--- a/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.FixedPoint;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Backmen.Mood;
+using Content.Shared.Backmen.Targeting;
 using Robust.Shared.Configuration;
 using Robust.Shared.Containers;
 
@@ -207,7 +208,7 @@ namespace Content.Server.Atmos.EntitySystems
 
         public override void Update(float frameTime)
         {
-            if (!_barotraumaEnabled)
+            if (!_barotraumaEnabled) // backmen edit
                 return;
 
             _timer += frameTime;
@@ -254,7 +255,13 @@ namespace Content.Server.Atmos.EntitySystems
                 if (pressure <= Atmospherics.HazardLowPressure)
                 {
                     // Deal damage and ignore resistances. Resistance to pressure damage should be done via pressure protection gear.
-                    _damageableSystem.TryChangeDamage(uid, barotrauma.Damage * Atmospherics.LowPressureDamage, true, false, partMultiplier: 0.5f); // backmen
+                    _damageableSystem.TryChangeDamage(
+                        uid,
+                        barotrauma.Damage * Atmospherics.LowPressureDamage,
+                        true,
+                        false,
+                        partMultiplier: 0.5f,
+                        targetPart: TargetBodyPart.All); // backmen
                     if (!barotrauma.TakingDamage)
                     {
                         barotrauma.TakingDamage = true;
@@ -268,7 +275,13 @@ namespace Content.Server.Atmos.EntitySystems
                     var damageScale = MathF.Min(((pressure / Atmospherics.HazardHighPressure) - 1) * Atmospherics.PressureDamageCoefficient, Atmospherics.MaxHighPressureDamage);
 
                     // Deal damage and ignore resistances. Resistance to pressure damage should be done via pressure protection gear.
-                    _damageableSystem.TryChangeDamage(uid, barotrauma.Damage * damageScale, true, false, partMultiplier: 0.5f); // backmen
+                    _damageableSystem.TryChangeDamage(
+                        uid,
+                        barotrauma.Damage * damageScale,
+                        true,
+                        false,
+                        partMultiplier: 0.5f,
+                        targetPart: TargetBodyPart.All); // backmen
                     RaiseLocalEvent(uid, new MoodEffectEvent("MobHighPressure")); // backmen: mood
 
                     if (!barotrauma.TakingDamage)

--- a/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
@@ -10,6 +10,8 @@ using Content.Shared.FixedPoint;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Backmen.Mood;
+using Content.Shared.Backmen.Surgery.Consciousness.Components;
+using Content.Shared.Backmen.Surgery.Wounds.Systems;
 using Content.Shared.Backmen.Targeting;
 using Robust.Shared.Configuration;
 using Robust.Shared.Containers;
@@ -24,6 +26,7 @@ namespace Content.Server.Atmos.EntitySystems
         [Dependency] private readonly AlertsSystem _alertsSystem = default!;
         [Dependency] private readonly IAdminLogManager _adminLogger= default!;
         [Dependency] private readonly InventorySystem _inventorySystem = default!;
+        [Dependency] private readonly WoundSystem _wounds = default!; // backmen edit: wounding
 
         private const float UpdateTimer = 1f;
         private float _timer;
@@ -232,6 +235,12 @@ namespace Content.Server.Atmos.EntitySystems
                         continue;
 
                     totalDamage += damage;
+                }
+
+                // backmen edit: Consciousness woundable damage check
+                if (HasComp<ConsciousnessComponent>(uid))
+                {
+                    totalDamage = _wounds.GetBodySeverityPoint(uid);
                 }
 
                 if (totalDamage >= barotrauma.MaxDamage)

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Graph.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Graph.cs
@@ -65,7 +65,7 @@ public abstract partial class SharedXenoArtifactSystem
     public bool TryGetNode(Entity<XenoArtifactComponent?> ent, int index, [NotNullWhen(true)] out Entity<XenoArtifactNodeComponent>? node)
     {
         node = null;
-        if (!Resolve(ent, ref ent.Comp))
+        if (!Resolve(ent, ref ent.Comp, false))
             return false;
 
         if (index < 0 || index >= ent.Comp.NodeVertices.Length)

--- a/Resources/Prototypes/Body/Parts/base.yml
+++ b/Resources/Prototypes/Body/Parts/base.yml
@@ -34,10 +34,6 @@
       path: /Audio/Medical/Surgery/organ1.ogg
     endSound:
       path: /Audio/Medical/Surgery/organ2.ogg
-  - type: Barotrauma
-    damage:
-      types:
-        Blunt: 1
   # end-backmen: surgery
   - type: ContainerContainer
     containers:

--- a/Resources/Prototypes/_Backmen/Entities/Objects/Weapons/Guns/guns64.yml
+++ b/Resources/Prototypes/_Backmen/Entities/Objects/Weapons/Guns/guns64.yml
@@ -342,10 +342,6 @@
     coldDamage:
       types:
         Cold: 5 #per second, scales with temperature & other constants
-  - type: Barotrauma
-    damage:
-      types:
-        Blunt: 5
   - type: AtmosExposed
   - type: TimedDespawn
     lifetime: 100


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Tweak
- [ ] Balance
- [ ] Refactor
- [ ] Port
- [ ] Translate
- [ ] Resprite

:cl: 
- fix: fixed barotrauma having insane amounts of damage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Исправления ошибок**
	- Исправлено применение баротравматического урона: теперь урон корректно распределяется по всем частям тела.
- **Изменения в балансe**
	- Удалён компонент баротравматического урона из базовой части тела и из сущности "ParticlesFireNRF".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->