### PR TITLE
фиксы команд, рук у ксено

### DIFF
--- a/Content.Server/Backmen/Administration/Commands/Toolshed/AddDiseaseCommand.cs
+++ b/Content.Server/Backmen/Administration/Commands/Toolshed/AddDiseaseCommand.cs
@@ -5,6 +5,7 @@ using Content.Server.Polymorph.Systems;
 using Content.Shared.Administration;
 using Content.Shared.Backmen.Disease;
 using Content.Shared.Polymorph;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Toolshed;
 using Robust.Shared.Toolshed.TypeParsers;
 
@@ -18,7 +19,7 @@ public sealed class AddDiseaseCommand : ToolshedCommand
     [CommandImplementation]
     public EntityUid? AddDisease(
         [PipedArgument] EntityUid input,
-        [CommandArgument] Prototype<DiseasePrototype> prototype
+        [CommandArgument] ProtoId<DiseasePrototype> prototype
     )
     {
         _diseaseSystem ??= GetSys<DiseaseSystem>();
@@ -30,7 +31,7 @@ public sealed class AddDiseaseCommand : ToolshedCommand
     [CommandImplementation]
     public IEnumerable<EntityUid> AddDisease(
         [PipedArgument] IEnumerable<EntityUid> input,
-        [CommandArgument] Prototype<DiseasePrototype> prototype
+        [CommandArgument] ProtoId<DiseasePrototype> prototype
     )
         => input.Select(x => AddDisease(x, prototype)).Where(x => x is not null).Select(x => (EntityUid) x!);
 }

--- a/Content.Server/Backmen/Administration/Commands/Toolshed/ChangeAccessCommand.cs
+++ b/Content.Server/Backmen/Administration/Commands/Toolshed/ChangeAccessCommand.cs
@@ -10,6 +10,7 @@ using Content.Shared.NPC.Components;
 using Content.Shared.NPC.Prototypes;
 using Content.Shared.NPC.Systems;
 using Content.Shared.Roles;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Toolshed;
 using Robust.Shared.Toolshed.Errors;
 using Robust.Shared.Toolshed.TypeParsers;
@@ -21,6 +22,7 @@ namespace Content.Server.Backmen.Administration.Commands.Toolshed;
 public sealed class ChangeAccessCommand : ToolshedCommand
 {
     private AccessSystem? _accessSystem;
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
 
     #region Set
 
@@ -28,7 +30,7 @@ public sealed class ChangeAccessCommand : ToolshedCommand
     private EntityUid? SetGroupAccessLevel(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid input,
-        [CommandArgument] Prototype<AccessGroupPrototype> accessGroupPrototype
+        [CommandArgument] ProtoId<AccessGroupPrototype> accessGroupPrototype
     )
     {
         _accessSystem ??= GetSys<AccessSystem>();
@@ -46,7 +48,7 @@ public sealed class ChangeAccessCommand : ToolshedCommand
     private IEnumerable<EntityUid> SetGroupAccessLevel(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] IEnumerable<EntityUid> input,
-        [CommandArgument] Prototype<AccessGroupPrototype> accessGroupPrototype
+        [CommandArgument] ProtoId<AccessGroupPrototype> accessGroupPrototype
     )
     {
         return input.Where(ent => SetGroupAccessLevel(ctx, ent, accessGroupPrototype) != null);
@@ -56,11 +58,11 @@ public sealed class ChangeAccessCommand : ToolshedCommand
     private EntityUid? SetJobAccessLevel(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid input,
-        [CommandArgument] Prototype<JobPrototype> jobPrototype
+        [CommandArgument] ProtoId<JobPrototype> jobPrototype
     )
     {
         _accessSystem ??= GetSys<AccessSystem>();
-        _accessSystem.SetAccessToJob(input, jobPrototype.Value, false);
+        _accessSystem.SetAccessToJob(input, _prototype.Index(jobPrototype), false);
         return input;
     }
 
@@ -68,7 +70,7 @@ public sealed class ChangeAccessCommand : ToolshedCommand
     private IEnumerable<EntityUid> SetJobAccessLevel(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] IEnumerable<EntityUid> input,
-        [CommandArgument] Prototype<JobPrototype> jobPrototype
+        [CommandArgument] ProtoId<JobPrototype> jobPrototype
     )
     {
         return input.Where(ent => SetJobAccessLevel(ctx, ent, jobPrototype) != null);
@@ -82,7 +84,7 @@ public sealed class ChangeAccessCommand : ToolshedCommand
     private EntityUid? AddAccessLevel(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid input,
-        [CommandArgument] Prototype<AccessLevelPrototype> accessPrototype
+        [CommandArgument] ProtoId<AccessLevelPrototype> accessPrototype
     )
     {
         _accessSystem ??= GetSys<AccessSystem>();
@@ -100,7 +102,7 @@ public sealed class ChangeAccessCommand : ToolshedCommand
     private IEnumerable<EntityUid> AddAccessLevel(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] IEnumerable<EntityUid> input,
-        [CommandArgument] Prototype<AccessLevelPrototype> accessPrototype
+        [CommandArgument] ProtoId<AccessLevelPrototype> accessPrototype
     )
     {
         return input.Where(ent => AddAccessLevel(ctx, ent, accessPrototype) != null);
@@ -110,7 +112,7 @@ public sealed class ChangeAccessCommand : ToolshedCommand
     private EntityUid? AddGroupAccessLevel(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid input,
-        [CommandArgument] Prototype<AccessGroupPrototype> accessGroupPrototype
+        [CommandArgument] ProtoId<AccessGroupPrototype> accessGroupPrototype
     )
     {
         _accessSystem ??= GetSys<AccessSystem>();
@@ -128,7 +130,7 @@ public sealed class ChangeAccessCommand : ToolshedCommand
     private IEnumerable<EntityUid> AddGroupAccessLevel(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] IEnumerable<EntityUid> input,
-        [CommandArgument] Prototype<AccessGroupPrototype> accessGroupPrototype
+        [CommandArgument] ProtoId<AccessGroupPrototype> accessGroupPrototype
     )
     {
         return input.Where(ent => AddGroupAccessLevel(ctx, ent, accessGroupPrototype) != null);
@@ -138,12 +140,12 @@ public sealed class ChangeAccessCommand : ToolshedCommand
     private EntityUid? AddJobAccessLevel(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid input,
-        [CommandArgument] Prototype<JobPrototype> jobPrototype
+        [CommandArgument] ProtoId<JobPrototype> jobPrototype
     )
     {
         _accessSystem ??= GetSys<AccessSystem>();
 
-        if (!_accessSystem.TryUnionWithJob(input, jobPrototype.Value, false))
+        if (!_accessSystem.TryUnionWithJob(input, _prototype.Index(jobPrototype), false))
         {
             ctx.ReportError(new AccessCompNotExists());
             return null;
@@ -156,7 +158,7 @@ public sealed class ChangeAccessCommand : ToolshedCommand
     private IEnumerable<EntityUid> AddJobAccessLevel(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] IEnumerable<EntityUid> input,
-        [CommandArgument] Prototype<JobPrototype> jobPrototype
+        [CommandArgument] ProtoId<JobPrototype> jobPrototype
     )
     {
         return input.Where(ent => AddJobAccessLevel(ctx, ent, jobPrototype) != null);
@@ -170,7 +172,7 @@ public sealed class ChangeAccessCommand : ToolshedCommand
     private EntityUid? RemoveAccessLevel(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid input,
-        [CommandArgument] Prototype<AccessLevelPrototype> accessPrototype
+        [CommandArgument] ProtoId<AccessLevelPrototype> accessPrototype
     )
     {
         _accessSystem ??= GetSys<AccessSystem>();
@@ -188,7 +190,7 @@ public sealed class ChangeAccessCommand : ToolshedCommand
     private IEnumerable<EntityUid> RemoveAccessLevel(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] IEnumerable<EntityUid> input,
-        [CommandArgument] Prototype<AccessLevelPrototype> accessPrototype
+        [CommandArgument] ProtoId<AccessLevelPrototype> accessPrototype
     )
     {
         return input.Where(ent => RemoveAccessLevel(ctx, ent, accessPrototype) != null);
@@ -198,7 +200,7 @@ public sealed class ChangeAccessCommand : ToolshedCommand
     private EntityUid? RemoveGroupAccessLevel(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid input,
-        [CommandArgument] Prototype<AccessGroupPrototype> accessGroupPrototype
+        [CommandArgument] ProtoId<AccessGroupPrototype> accessGroupPrototype
     )
     {
         _accessSystem ??= GetSys<AccessSystem>();
@@ -216,7 +218,7 @@ public sealed class ChangeAccessCommand : ToolshedCommand
     private IEnumerable<EntityUid> RemoveGroupAccessLevel(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] IEnumerable<EntityUid> input,
-        [CommandArgument] Prototype<AccessGroupPrototype> accessGroupPrototype
+        [CommandArgument] ProtoId<AccessGroupPrototype> accessGroupPrototype
     )
     {
         return input.Where(ent => RemoveGroupAccessLevel(ctx, ent, accessGroupPrototype) != null);
@@ -226,12 +228,12 @@ public sealed class ChangeAccessCommand : ToolshedCommand
     private EntityUid? RemoveJobAccessLevel(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid input,
-        [CommandArgument] Prototype<JobPrototype> jobPrototype
+        [CommandArgument] ProtoId<JobPrototype> jobPrototype
     )
     {
         _accessSystem ??= GetSys<AccessSystem>();
 
-        if (!_accessSystem.TryExceptWithJob(input, jobPrototype.Value, false))
+        if (!_accessSystem.TryExceptWithJob(input, _prototype.Index(jobPrototype), false))
         {
             ctx.ReportError(new AccessCompNotExists());
             return null;
@@ -244,7 +246,7 @@ public sealed class ChangeAccessCommand : ToolshedCommand
     private IEnumerable<EntityUid> RemoveJobAccessLevel(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] IEnumerable<EntityUid> input,
-        [CommandArgument] Prototype<JobPrototype> jobPrototype
+        [CommandArgument] ProtoId<JobPrototype> jobPrototype
     )
     {
         return input.Where(ent => RemoveJobAccessLevel(ctx, ent, jobPrototype) != null);

--- a/Content.Server/Backmen/Administration/Commands/Toolshed/ChangeAccessReaderCommand.cs
+++ b/Content.Server/Backmen/Administration/Commands/Toolshed/ChangeAccessReaderCommand.cs
@@ -6,6 +6,7 @@ using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared.Administration;
 using Content.Shared.Roles;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Toolshed;
 using Robust.Shared.Toolshed.Errors;
 using Robust.Shared.Toolshed.TypeParsers;
@@ -17,6 +18,8 @@ namespace Content.Server.Backmen.Administration.Commands.Toolshed;
 public sealed class ChangeAccessReaderCommand : ToolshedCommand
 {
     private AccessReaderSystem? _accessReaderSystem;
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+
 
     #region Add
 
@@ -24,7 +27,7 @@ public sealed class ChangeAccessReaderCommand : ToolshedCommand
     private EntityUid? AddAccessReader(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid input,
-        [CommandArgument] Prototype<AccessLevelPrototype> accessPrototype
+        [CommandArgument] ProtoId<AccessLevelPrototype> accessPrototype
     )
     {
         _accessReaderSystem ??= GetSys<AccessReaderSystem>();
@@ -42,7 +45,7 @@ public sealed class ChangeAccessReaderCommand : ToolshedCommand
     private IEnumerable<EntityUid> AddAccessReader(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] IEnumerable<EntityUid> input,
-        [CommandArgument] Prototype<AccessLevelPrototype> accessPrototype
+        [CommandArgument] ProtoId<AccessLevelPrototype> accessPrototype
     )
     {
         return input.Where(ent => AddAccessReader(ctx, ent, accessPrototype) != null);
@@ -52,7 +55,7 @@ public sealed class ChangeAccessReaderCommand : ToolshedCommand
     private EntityUid? AddGroupAccessReader(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid input,
-        [CommandArgument] Prototype<AccessGroupPrototype> accessGroupPrototype
+        [CommandArgument] ProtoId<AccessGroupPrototype> accessGroupPrototype
     )
     {
         _accessReaderSystem ??= GetSys<AccessReaderSystem>();
@@ -70,7 +73,7 @@ public sealed class ChangeAccessReaderCommand : ToolshedCommand
     private IEnumerable<EntityUid> AddGroupAccessReader(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] IEnumerable<EntityUid> input,
-        [CommandArgument] Prototype<AccessGroupPrototype> accessGroupPrototype
+        [CommandArgument] ProtoId<AccessGroupPrototype> accessGroupPrototype
     )
     {
         return input.Where(ent => AddGroupAccessReader(ctx, ent, accessGroupPrototype) != null);
@@ -80,7 +83,7 @@ public sealed class ChangeAccessReaderCommand : ToolshedCommand
     private EntityUid? AddJobAccessReader(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid input,
-        [CommandArgument] Prototype<JobPrototype> jobPrototype
+        [CommandArgument] ProtoId<JobPrototype> jobPrototype
     )
     {
         _accessReaderSystem ??= GetSys<AccessReaderSystem>();
@@ -90,7 +93,7 @@ public sealed class ChangeAccessReaderCommand : ToolshedCommand
             return null;
         }
 
-        _accessReaderSystem.AddAccessByJob((input, comp), jobPrototype.Value);
+        _accessReaderSystem.AddAccessByJob((input, comp), _prototype.Index(jobPrototype));
 
         return input;
     }
@@ -99,7 +102,7 @@ public sealed class ChangeAccessReaderCommand : ToolshedCommand
     private IEnumerable<EntityUid> AddJobAccessReader(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] IEnumerable<EntityUid> input,
-        [CommandArgument] Prototype<JobPrototype> jobPrototype
+        [CommandArgument] ProtoId<JobPrototype> jobPrototype
     )
     {
         return input.Where(ent => AddJobAccessReader(ctx, ent, jobPrototype) != null);
@@ -113,7 +116,7 @@ public sealed class ChangeAccessReaderCommand : ToolshedCommand
     private EntityUid? RemoveAccessReader(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid input,
-        [CommandArgument] Prototype<AccessLevelPrototype> accessPrototype
+        [CommandArgument] ProtoId<AccessLevelPrototype> accessPrototype
     )
     {
         _accessReaderSystem ??= GetSys<AccessReaderSystem>();
@@ -132,7 +135,7 @@ public sealed class ChangeAccessReaderCommand : ToolshedCommand
     private IEnumerable<EntityUid> RemoveAccessReader(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] IEnumerable<EntityUid> input,
-        [CommandArgument] Prototype<AccessLevelPrototype> accessPrototype
+        [CommandArgument] ProtoId<AccessLevelPrototype> accessPrototype
     )
     {
         return input.Where(ent => RemoveAccessReader(ctx, ent, accessPrototype) != null);
@@ -142,7 +145,7 @@ public sealed class ChangeAccessReaderCommand : ToolshedCommand
     private EntityUid? RemoveGroupAccessReader(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid input,
-        [CommandArgument] Prototype<AccessGroupPrototype> accessGroupPrototype
+        [CommandArgument] ProtoId<AccessGroupPrototype> accessGroupPrototype
     )
     {
         _accessReaderSystem ??= GetSys<AccessReaderSystem>();
@@ -162,7 +165,7 @@ public sealed class ChangeAccessReaderCommand : ToolshedCommand
     private IEnumerable<EntityUid> RemoveGroupAccessReader(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] IEnumerable<EntityUid> input,
-        [CommandArgument] Prototype<AccessGroupPrototype> accessGroupPrototype
+        [CommandArgument] ProtoId<AccessGroupPrototype> accessGroupPrototype
     )
     {
         return input.Where(ent => RemoveGroupAccessReader(ctx, ent, accessGroupPrototype) != null);
@@ -172,7 +175,7 @@ public sealed class ChangeAccessReaderCommand : ToolshedCommand
     private EntityUid? RemoveJobAccessReader(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid input,
-        [CommandArgument] Prototype<JobPrototype> jobPrototype
+        [CommandArgument] ProtoId<JobPrototype> jobPrototype
     )
     {
         _accessReaderSystem ??= GetSys<AccessReaderSystem>();
@@ -183,7 +186,7 @@ public sealed class ChangeAccessReaderCommand : ToolshedCommand
             return null;
         }
 
-        _accessReaderSystem.RemoveAccessByJob((input, comp), jobPrototype.Value);
+        _accessReaderSystem.RemoveAccessByJob((input, comp), _prototype.Index(jobPrototype));
 
         return input;
     }
@@ -192,7 +195,7 @@ public sealed class ChangeAccessReaderCommand : ToolshedCommand
     private IEnumerable<EntityUid> RemoveJobAccessReader(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] IEnumerable<EntityUid> input,
-        [CommandArgument] Prototype<JobPrototype> jobPrototype
+        [CommandArgument] ProtoId<JobPrototype> jobPrototype
     )
     {
         return input.Where(ent => RemoveJobAccessReader(ctx, ent, jobPrototype) != null);
@@ -238,7 +241,7 @@ public sealed class ChangeAccessReaderCommand : ToolshedCommand
     private EntityUid? SetGroupAccessReader(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid input,
-        [CommandArgument] Prototype<AccessGroupPrototype> accessGroupPrototype
+        [CommandArgument] ProtoId<AccessGroupPrototype> accessGroupPrototype
     )
     {
         _accessReaderSystem ??= GetSys<AccessReaderSystem>();
@@ -258,7 +261,7 @@ public sealed class ChangeAccessReaderCommand : ToolshedCommand
     private IEnumerable<EntityUid> SetGroupAccessReader(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] IEnumerable<EntityUid> input,
-        [CommandArgument] Prototype<AccessGroupPrototype> accessGroupPrototype
+        [CommandArgument] ProtoId<AccessGroupPrototype> accessGroupPrototype
     )
     {
         return input.Where(ent => SetGroupAccessReader(ctx, ent, accessGroupPrototype) != null);
@@ -268,7 +271,7 @@ public sealed class ChangeAccessReaderCommand : ToolshedCommand
     private EntityUid? SetJobAccessReader(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid input,
-        [CommandArgument] Prototype<JobPrototype> jobPrototype
+        [CommandArgument] ProtoId<JobPrototype> jobPrototype
     )
     {
         _accessReaderSystem ??= GetSys<AccessReaderSystem>();
@@ -278,7 +281,7 @@ public sealed class ChangeAccessReaderCommand : ToolshedCommand
             return null;
         }
 
-        _accessReaderSystem.SetAccessByJob((input, comp), jobPrototype.Value);
+        _accessReaderSystem.SetAccessByJob((input, comp), _prototype.Index(jobPrototype));
         return input;
     }
 
@@ -286,7 +289,7 @@ public sealed class ChangeAccessReaderCommand : ToolshedCommand
     private IEnumerable<EntityUid> SetJobAccessReader(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] IEnumerable<EntityUid> input,
-        [CommandArgument] Prototype<JobPrototype> jobPrototype
+        [CommandArgument] ProtoId<JobPrototype> jobPrototype
     )
     {
         return input.Where(ent => SetJobAccessReader(ctx, ent, jobPrototype) != null);

--- a/Content.Server/Backmen/Administration/Commands/Toolshed/ChangeFactionCommand.cs
+++ b/Content.Server/Backmen/Administration/Commands/Toolshed/ChangeFactionCommand.cs
@@ -5,6 +5,7 @@ using Content.Shared.Administration;
 using Content.Shared.NPC.Components;
 using Content.Shared.NPC.Prototypes;
 using Content.Shared.NPC.Systems;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Toolshed;
 using Robust.Shared.Toolshed.Errors;
 using Robust.Shared.Toolshed.TypeParsers;
@@ -23,11 +24,11 @@ public sealed class ChangeFactionCommand : ToolshedCommand
     private EntityUid AddFaction(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid input,
-        [CommandArgument] Prototype<NpcFactionPrototype> factionData
+        [CommandArgument] ProtoId<NpcFactionPrototype> factionData
     )
     {
         _npcFactionSystem ??= GetSys<NpcFactionSystem>();
-        _npcFactionSystem.AddFaction(input, factionData.Id);
+        _npcFactionSystem.AddFaction(input, factionData);
         return input;
     }
 
@@ -35,7 +36,7 @@ public sealed class ChangeFactionCommand : ToolshedCommand
     private IEnumerable<EntityUid> AddFaction(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] IEnumerable<EntityUid> input,
-        [CommandArgument] Prototype<NpcFactionPrototype> factionData
+        [CommandArgument] ProtoId<NpcFactionPrototype> factionData
     )
     {
         return input.Select(member => AddFaction(ctx, member, factionData));
@@ -49,7 +50,7 @@ public sealed class ChangeFactionCommand : ToolshedCommand
     private EntityUid RemoveFaction(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid input,
-        [CommandArgument] Prototype<NpcFactionPrototype> factionData
+        [CommandArgument] ProtoId<NpcFactionPrototype> factionData
     )
     {
         _npcFactionSystem ??= GetSys<NpcFactionSystem>();
@@ -61,7 +62,7 @@ public sealed class ChangeFactionCommand : ToolshedCommand
     private IEnumerable<EntityUid> RemoveFaction(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] IEnumerable<EntityUid> input,
-        [CommandArgument] Prototype<NpcFactionPrototype> factionData
+        [CommandArgument] ProtoId<NpcFactionPrototype> factionData
     )
     {
         return input.Select(member => RemoveFaction(ctx, member, factionData));

--- a/Content.Server/Backmen/Administration/Commands/Toolshed/ChangeLaws.cs
+++ b/Content.Server/Backmen/Administration/Commands/Toolshed/ChangeLaws.cs
@@ -4,6 +4,7 @@ using Content.Server.Silicons.Laws;
 using Content.Shared.Administration;
 using Content.Shared.Silicons.Laws;
 using Content.Shared.Silicons.Laws.Components;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Toolshed;
 using Robust.Shared.Toolshed.TypeParsers;
 
@@ -13,6 +14,7 @@ namespace Content.Server.Backmen.Administration.Commands.Toolshed;
 public sealed class LawsCommand : ToolshedCommand
 {
     private SiliconLawSystem? _law;
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
 
     [CommandImplementation("list")]
     public IEnumerable<EntityUid> List()
@@ -39,12 +41,12 @@ public sealed class LawsCommand : ToolshedCommand
     public EntityUid? SetLaws(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid input,
-        [CommandArgument] Prototype<SiliconLawsetPrototype> siliconLawSetPrototype
+        [CommandArgument] ProtoId<SiliconLawsetPrototype> siliconLawSetPrototype
     )
     {
         _law ??= GetSys<SiliconLawSystem>();
 
-        _law.SetLaws(input, siliconLawSetPrototype.Value);
+        _law.SetLaws(input, _prototype.Index(siliconLawSetPrototype));
         return input;
     }
 
@@ -52,10 +54,10 @@ public sealed class LawsCommand : ToolshedCommand
     public IEnumerable<EntityUid> SetLaws(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] IEnumerable<EntityUid> input,
-        [CommandArgument] Prototype<SiliconLawsetPrototype> siliconLawSetPrototype
+        [CommandArgument] ProtoId<SiliconLawsetPrototype> siliconLawSetPrototype
     )
     {
-        return input.Where(ent => SetLaws(ctx, ent, siliconLawSetPrototype) != null);
+        return input.Where(ent => SetLaws(ctx, ent, _prototype.Index(siliconLawSetPrototype)) != null);
     }
 
     [CommandImplementation("override")]

--- a/Content.Server/Backmen/Administration/Commands/Toolshed/ChangeTTSCommand.cs
+++ b/Content.Server/Backmen/Administration/Commands/Toolshed/ChangeTTSCommand.cs
@@ -7,6 +7,7 @@ using Content.Shared.Administration;
 using Content.Shared.Backmen.Disease;
 using Content.Shared.Corvax.TTS;
 using Content.Shared.Humanoid;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Toolshed;
 using Robust.Shared.Toolshed.TypeParsers;
 
@@ -21,7 +22,7 @@ public sealed class ChangeTTSCommand : ToolshedCommand
     public EntityUid? ChangeTTS(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid input,
-        [CommandArgument] Prototype<TTSVoicePrototype> prototype
+        [CommandArgument] ProtoId<TTSVoicePrototype> prototype
     )
     {
         if (EntityManager.TryGetComponent<HumanoidAppearanceComponent>(input, out var humanoidAppearanceComponent))
@@ -42,7 +43,7 @@ public sealed class ChangeTTSCommand : ToolshedCommand
     public IEnumerable<EntityUid> ChangeTTS(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] IEnumerable<EntityUid> input,
-        [CommandArgument] Prototype<TTSVoicePrototype> prototype
+        [CommandArgument] ProtoId<TTSVoicePrototype> prototype
     )
         => input.Select(x => ChangeTTS(ctx, x, prototype)).Where(x => x is not null).Select(x => (EntityUid) x!);
 }

--- a/Content.Server/Backmen/Administration/Commands/Toolshed/StationRecordCommand.cs
+++ b/Content.Server/Backmen/Administration/Commands/Toolshed/StationRecordCommand.cs
@@ -35,7 +35,7 @@ public sealed class StationRecordCommand : ToolshedCommand
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid input,
         [CommandArgument] ValueRef<ICommonSession> playerRef,
-        [CommandArgument] Prototype<JobPrototype> job)
+        [CommandArgument] ProtoId<JobPrototype> job)
     {
         var player = playerRef.Evaluate(ctx);
         if (player is null || player.AttachedEntity is null ||
@@ -113,7 +113,7 @@ public sealed class StationRecordCommand : ToolshedCommand
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] IEnumerable<EntityUid> input,
         [CommandArgument] ValueRef<ICommonSession> playerRef,
-        [CommandArgument] Prototype<JobPrototype> job
+        [CommandArgument] ProtoId<JobPrototype> job
     )
         => input.Select(x => Add(ctx, x, playerRef, job));
 

--- a/Content.Server/Backmen/Language/Commands/AdminLanguageCommand.cs
+++ b/Content.Server/Backmen/Language/Commands/AdminLanguageCommand.cs
@@ -20,7 +20,7 @@ public sealed class AdminLanguageCommand : ToolshedCommand
     public EntityUid AddLanguage(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid input,
-        [CommandArgument] Prototype<LanguagePrototype> prototype,
+        [CommandArgument] ProtoId<LanguagePrototype> prototype,
         [CommandArgument] bool canSpeak = true,
         [CommandArgument] bool canUnderstand = true
     )
@@ -43,7 +43,7 @@ public sealed class AdminLanguageCommand : ToolshedCommand
     public EntityUid RemoveLanguage(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid input,
-        [CommandArgument] Prototype<LanguagePrototype> prototype,
+        [CommandArgument] ProtoId<LanguagePrototype> prototype,
         [CommandArgument] bool removeSpeak = true,
         [CommandArgument] bool removeUnderstand = true
     )

--- a/Content.Server/Backmen/Language/Commands/AdminTranslatorCommand.cs
+++ b/Content.Server/Backmen/Language/Commands/AdminTranslatorCommand.cs
@@ -6,6 +6,7 @@ using Content.Shared.Backmen.Language.Components;
 using Content.Shared.Backmen.Language.Components.Translators;
 using Content.Shared.Backmen.Language.Systems;
 using Robust.Server.Containers;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Toolshed;
 using Robust.Shared.Toolshed.Syntax;
 using Robust.Shared.Toolshed.TypeParsers;
@@ -25,7 +26,7 @@ public sealed class AdminTranslatorCommand : ToolshedCommand
     public EntityUid AddLanguage(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid input,
-        [CommandArgument] Prototype<LanguagePrototype> language,
+        [CommandArgument] ProtoId<LanguagePrototype> language,
         [CommandArgument] bool addSpeak = true,
         [CommandArgument] bool addUnderstand = true
     )
@@ -51,7 +52,7 @@ public sealed class AdminTranslatorCommand : ToolshedCommand
     public EntityUid RemoveLanguage(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid input,
-        [CommandArgument] Prototype<LanguagePrototype> language,
+        [CommandArgument] ProtoId<LanguagePrototype> language,
         [CommandArgument] bool removeSpeak = true,
         [CommandArgument] bool removeUnderstand = true
     )
@@ -73,7 +74,7 @@ public sealed class AdminTranslatorCommand : ToolshedCommand
     public EntityUid AddRequiredLanguage(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid input,
-        [CommandArgument] Prototype<LanguagePrototype> language)
+        [CommandArgument] ProtoId<LanguagePrototype> language)
     {
         if (!TryGetTranslatorComp(input, out var translator))
             throw new ArgumentException(Loc.GetString("command-language-error-not-a-translator", ("entity", input)));
@@ -91,7 +92,7 @@ public sealed class AdminTranslatorCommand : ToolshedCommand
     public EntityUid RemoveRequiredLanguage(
         [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid input,
-        [CommandArgument] Prototype<LanguagePrototype> language)
+        [CommandArgument] ProtoId<LanguagePrototype> language)
     {
         if (!TryGetTranslatorComp(input, out var translator))
             throw new ArgumentException(Loc.GetString("command-language-error-not-a-translator", ("entity", input)));

--- a/Content.Server/StationEvents/BasicStationEventSchedulerSystem.cs
+++ b/Content.Server/StationEvents/BasicStationEventSchedulerSystem.cs
@@ -80,6 +80,9 @@ namespace Content.Server.StationEvents
         private IComponentFactory? _compFac;
         private IRobustRandom? _random;
 
+        [Dependency] private readonly IPrototypeManager _prototype = default!;
+
+
         /// <summary>
         ///     Estimates the expected number of times an event will run over the course of X rounds, taking into account weights and
         ///     how many events are expected to run over a given timeframe for a given playercount by repeatedly simulating rounds.
@@ -95,7 +98,7 @@ namespace Content.Server.StationEvents
         ///     to even exist) so I think it's fine.
         /// </remarks>
         [CommandImplementation("simulate")]
-        public IEnumerable<(string, float)> Simulate([CommandArgument] Prototype<EntityPrototype> eventSchedulerProto, [CommandArgument] int rounds, [CommandArgument] int playerCount, [CommandArgument] float roundEndMean, [CommandArgument] float roundEndStdDev)
+        public IEnumerable<(string, float)> Simulate([CommandArgument] ProtoId<EntityPrototype> eventSchedulerProto, [CommandArgument] int rounds, [CommandArgument] int playerCount, [CommandArgument] float roundEndMean, [CommandArgument] float roundEndStdDev)
         {
             _stationEvent ??= GetSys<EventManagerSystem>();
             _entityTable ??= GetSys<EntityTableSystem>();
@@ -109,7 +112,7 @@ namespace Content.Server.StationEvents
                 occurrences.Add(ev.Key.ID, 0);
             }
 
-            eventSchedulerProto.Deconstruct(out EntityPrototype eventScheduler);
+            var eventScheduler = _prototype.Index(eventSchedulerProto);
 
             if (!eventScheduler.TryGetComponent<BasicStationEventSchedulerComponent>(out var basicScheduler, _compFac))
             {
@@ -148,12 +151,12 @@ namespace Content.Server.StationEvents
         }
 
         [CommandImplementation("lsprob")]
-        public IEnumerable<(string, float)> LsProb([CommandArgument] Prototype<EntityPrototype> eventSchedulerProto)
+        public IEnumerable<(string, float)> LsProb([CommandArgument] ProtoId<EntityPrototype> eventSchedulerProto)
         {
             _compFac ??= IoCManager.Resolve<IComponentFactory>();
             _stationEvent ??= GetSys<EventManagerSystem>();
 
-            eventSchedulerProto.Deconstruct(out EntityPrototype eventScheduler);
+            var eventScheduler = _prototype.Index(eventSchedulerProto);
 
             if (!eventScheduler.TryGetComponent<BasicStationEventSchedulerComponent>(out var basicScheduler, _compFac))
                 yield break;
@@ -171,12 +174,12 @@ namespace Content.Server.StationEvents
         }
 
         [CommandImplementation("lsprobtheoretical")]
-        public IEnumerable<(string, float)> LsProbTime([CommandArgument] Prototype<EntityPrototype> eventSchedulerProto, [CommandArgument] int playerCount, [CommandArgument] float time)
+        public IEnumerable<(string, float)> LsProbTime([CommandArgument] ProtoId<EntityPrototype> eventSchedulerProto, [CommandArgument] int playerCount, [CommandArgument] float time)
         {
             _compFac ??= IoCManager.Resolve<IComponentFactory>();
             _stationEvent ??= GetSys<EventManagerSystem>();
 
-            eventSchedulerProto.Deconstruct(out EntityPrototype eventScheduler);
+            var eventScheduler = _prototype.Index(eventSchedulerProto);
 
             if (!eventScheduler.TryGetComponent<BasicStationEventSchedulerComponent>(out var basicScheduler, _compFac))
                 yield break;
@@ -198,12 +201,12 @@ namespace Content.Server.StationEvents
         }
 
         [CommandImplementation("prob")]
-        public float Prob([CommandArgument] Prototype<EntityPrototype> eventSchedulerProto, [CommandArgument] string eventId)
+        public float Prob([CommandArgument] ProtoId<EntityPrototype> eventSchedulerProto, [CommandArgument] string eventId)
         {
             _compFac ??= IoCManager.Resolve<IComponentFactory>();
             _stationEvent ??= GetSys<EventManagerSystem>();
 
-            eventSchedulerProto.Deconstruct(out EntityPrototype eventScheduler);
+            var eventScheduler = _prototype.Index(eventSchedulerProto);
 
             if (!eventScheduler.TryGetComponent<BasicStationEventSchedulerComponent>(out var basicScheduler, _compFac))
                 return 0f;

--- a/Content.Server/Tools/Innate/InnateToolSystem.cs
+++ b/Content.Server/Tools/Innate/InnateToolSystem.cs
@@ -81,7 +81,7 @@ public sealed class InnateToolSystem : EntitySystem
         var item = Spawn(toSpawn, spawnCoord);
         if (!_sharedHandsSystem.TryPickupAnyHand(uid, item, checkActionBlocker: false))
         {
-            QueueDel(item);
+            Del(item);
             component.ToSpawn.Remove(toSpawn);
             return;
         }

--- a/Resources/Prototypes/_Backmen/Entities/Mobs/NPCs/TGMC_xeno.yml
+++ b/Resources/Prototypes/_Backmen/Entities/Mobs/NPCs/TGMC_xeno.yml
@@ -320,7 +320,7 @@
     raffle:
       settings: default
   - type: Body
-    prototype: Xeno4hand
+    prototype: XenoBody
   - type: InnateTool
     tools:
       - id: WeaponXenoQueenClaw
@@ -412,7 +412,7 @@
   - type: NameIdentifier
     group: Xeno
   - type: Body
-    prototype: Xeno2hand
+    prototype: XenoBody
   - type: Fixtures
     fixtures:
       fix1:
@@ -448,7 +448,7 @@
     raffle:
       settings: default
   - type: Body
-    prototype: Xeno4hand
+    prototype: XenoBody
   - type: InnateTool
     tools:
       - id: WeaponXenoClaw
@@ -509,7 +509,7 @@
     raffle:
       settings: default
   - type: Body
-    prototype: Xeno4hand
+    prototype: XenoBody
   - type: HTN
     rootTask:
       task: SimpleHumanoidHostileCompound
@@ -653,7 +653,7 @@
   - type: NameIdentifier
     group: Xeno
   - type: Body
-    prototype: Xeno3hand
+    prototype: XenoBody
   - type: InnateTool
     tools:
       - id: WeaponXenoClaw
@@ -717,7 +717,7 @@
   - type: NameIdentifier
     group: Xeno
   - type: Body
-    prototype: Xeno2hand
+    prototype: XenoBody
   - type: StealthOnMove
     passiveVisibilityRate: -2
     movementVisibilityRate: 0.1
@@ -754,7 +754,7 @@
     raffle:
       settings: default
   - type: Body
-    prototype: Xeno3hand
+    prototype: XenoBody
   - type: Damageable
     damageContainer: Biological
     damageModifierSet: XenolianStrong
@@ -830,7 +830,7 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: running
   - type: Body
-    prototype: Xeno4hand
+    prototype: XenoBody
   - type: Damageable
     damageContainer: Biological
     damageModifierSet: XenolianStrong
@@ -878,94 +878,12 @@
 # BODY PRESETS #
 
 - type: body
-  id: Xeno1hand
+  id: XenoBody
   name: "xeno"
   root: torso
   slots:
     torso:
       part: ChestReptilian
-      connections:
-      - hand 1
-    hand 1:
-      part: XenoArm
-
-- type: body
-  id: Xeno2hand
-  name: "xeno"
-  root: torso
-  slots:
-    torso:
-      part: ChestReptilian
-      connections:
-      - hand 1
-      - hand 2
-    hand 1:
-      part: XenoArm
-    hand 2:
-      part: XenoArm
-
-- type: body
-  id: Xeno3hand
-  name: "xeno"
-  root: torso
-  slots:
-    torso:
-      part: ChestReptilian
-      connections:
-      - hand 1
-      - hand 2
-      - hand 3
-    hand 1:
-      part: XenoArm
-    hand 2:
-      part: XenoArm
-    hand 3:
-      part: XenoArm
-
-- type: body
-  id: Xeno4hand
-  name: "xeno"
-  root: torso
-  slots:
-    torso:
-      part: ChestReptilian
-      connections:
-      - hand 1
-      - hand 2
-      - hand 3
-      - hand 4
-    hand 1:
-      part: XenoArm
-    hand 2:
-      part: XenoArm
-    hand 3:
-      part: XenoArm
-    hand 4:
-      part: XenoArm
-
-- type: body
-  id: Xeno5hand
-  name: "xeno"
-  root: torso
-  slots:
-    torso:
-      part: ChestReptilian
-      connections:
-      - hand 1
-      - hand 2
-      - hand 3
-      - hand 4
-      - hand 5
-    hand 1:
-      part: XenoArm
-    hand 2:
-      part: XenoArm
-    hand 3:
-      part: XenoArm
-    hand 4:
-      part: XenoArm
-    hand 5:
-      part: XenoArm
 
 - type: entity
   id: XenoArm


### PR DESCRIPTION

:cl: 
- fix: У ксено больше нет лишних рук


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Рефакторинг**
  - В административных командах изменён способ указания прототипов: теперь вместо передачи полного объекта прототипа используется его идентификатор. Это затрагивает команды для изменения болезней, доступа, фракций, законов, TTS-голоса, языков и событий станции.
  - Обновлены методы команд для работы с идентификаторами прототипов, что повышает унификацию и удобство использования.
  - Упрощено определение тела ксеноморфов: все NPC теперь используют единый прототип тела XenoBody вместо нескольких вариантов с разным количеством рук.
- **Мелкие улучшения**
  - При невозможности подобрать предмет, созданный врождённым инструментом, он теперь удаляется сразу, а не с задержкой.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->