### PR TITLE
[Balance] Nerf Pipe Stacking

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
@@ -6,6 +6,7 @@
     mode: SnapgridCenter
   components:
   - type: AtmosDevice
+  - type: PipeRestrictOverlap # backmen change: no atmos abusing
   - type: Tag
     tags:
       - Unstackable


### PR DESCRIPTION
Теперь атмосферным девайсам полностью запрещено стакаться с другими трубами. Стаки труб пригодятся только для самих труб, чтобы добавить новое соединение не разбирая всю систему.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Новые функции**
	- Добавлен компонент, ограничивающий перекрытие труб в атмосферных системах.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->