### PR TITLE
Krutie bug fixi

### DIFF
--- a/Content.Server/Backmen/Surgery/Wounds/Systems/ServerWoundSystem.cs
+++ b/Content.Server/Backmen/Surgery/Wounds/Systems/ServerWoundSystem.cs
@@ -12,7 +12,6 @@ using Content.Shared.Body.Systems;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.FixedPoint;
-using Content.Shared.Humanoid;
 using Content.Shared.Inventory;
 using JetBrains.Annotations;
 using Robust.Shared.Prototypes;
@@ -94,12 +93,15 @@ public sealed class ServerWoundSystem : WoundSystem
                 continue;
 
             var woundsToHeal =
-                GetWoundableWounds(ent, woundable).Where(wound => CanHealWound(wound, wound)).ToList();
+                GetWoundableWounds(ent, woundable)
+                    .Where(wound => CanHealWound(wound, wound))
+                    .Where(wound => wound.Comp.DamagedLastTime < Timing.CurTime + wound.Comp.CanHealAfter)
+                    .ToArray();
 
-            if (woundsToHeal.Count == 0)
+            if (woundsToHeal.Length == 0)
                 continue;
 
-            var healAmount = -woundable.HealAbility / woundsToHeal.Count;
+            var healAmount = -woundable.HealAbility / woundsToHeal.Length;
 
             Entity<WoundableComponent> owner = (ent, woundable);
             foreach (var x in woundsToHeal)

--- a/Content.Server/Backmen/Surgery/Wounds/Systems/ServerWoundSystem.cs
+++ b/Content.Server/Backmen/Surgery/Wounds/Systems/ServerWoundSystem.cs
@@ -95,7 +95,7 @@ public sealed class ServerWoundSystem : WoundSystem
             var woundsToHeal =
                 GetWoundableWounds(ent, woundable)
                     .Where(wound => CanHealWound(wound, wound))
-                    .Where(wound => wound.Comp.DamagedLastTime < Timing.CurTime + wound.Comp.CanHealAfter)
+                    .Where(wound => wound.Comp.DamagedLastTime + wound.Comp.CanHealAfter < Timing.CurTime)
                     .ToArray();
 
             if (woundsToHeal.Length == 0)

--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -328,32 +328,6 @@ public sealed class RespiratorSystem : EntitySystem
             RaiseLocalEvent(ent, new MoodEffectEvent("Suffocating")); // backmen: mood
         }
 
-        // backmen edit start
-        if (_consciousness.TryGetNerveSystem(ent, out var nerveSys))
-        {
-            if (!_consciousness.TryGetConsciousnessModifier(ent, nerveSys.Value, out var modifier, "Suffocation"))
-            {
-                _consciousness.AddConsciousnessModifier(
-                    ent,
-                    nerveSys.Value,
-                    -ent.Comp.Damage.GetTotal(),
-                    identifier: "Suffocation",
-                    type: ConsciousnessModType.Pain);
-            }
-            else
-            {
-                _consciousness.SetConsciousnessModifier(
-                    ent,
-                    nerveSys.Value,
-                    modifier.Value.Change - ent.Comp.Damage.GetTotal(),
-                    identifier: "Suffocation",
-                    type: ConsciousnessModType.Pain);
-            }
-
-            return;
-        }
-        // backmen edit end
-
         _damageableSys.TryChangeDamage(ent, ent.Comp.Damage, interruptsDoAfters: false);
     }
 
@@ -367,17 +341,6 @@ public sealed class RespiratorSystem : EntitySystem
         foreach (var entity in organs)
         {
             _alertsSystem.ClearAlert(ent, entity.Comp1.Alert);
-        }
-
-        if (_consciousness.TryGetNerveSystem(ent, out var nerveSys))
-        {
-            _consciousness.ChangeConsciousnessModifier(
-                ent,
-                nerveSys.Value,
-                FixedPoint2.Abs(ent.Comp.DamageRecovery.GetTotal()),
-                "Suffocation");
-
-            return;
         }
 
         _damageableSys.TryChangeDamage(ent, ent.Comp.DamageRecovery);

--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -343,7 +343,7 @@ public sealed class NPCUtilitySystem : EntitySystem
             }
             case TargetIsCritCon:
             {
-                return _mobState.IsCritical(targetUid) ? 1f : 0f;
+                return _mobState.IsHardCritical(targetUid) ? 1f : 0f; // backmen edit: soft crit
             }
             case TargetIsDeadCon:
             {

--- a/Content.Shared/Backmen/Surgery/Wounds/Components/WoundComponent.cs
+++ b/Content.Shared/Backmen/Surgery/Wounds/Components/WoundComponent.cs
@@ -42,6 +42,18 @@ public sealed partial class WoundComponent : Component
     public WoundType WoundType = WoundType.External;
 
     /// <summary>
+    /// Self-explanatory
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly)]
+    public TimeSpan DamagedLastTime;
+
+    /// <summary>
+    /// Self-explanatory, right now only applies for passive healing; Basically: Clotting
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField]
+    public TimeSpan CanHealAfter = TimeSpan.FromSeconds(15f);
+
+    /// <summary>
     /// Damage group of this wound.
     /// </summary>
     [ViewVariables(VVAccess.ReadOnly), DataField]

--- a/Content.Shared/Backmen/Surgery/Wounds/Systems/WoundSystem.cs
+++ b/Content.Shared/Backmen/Surgery/Wounds/Systems/WoundSystem.cs
@@ -20,6 +20,7 @@ using Robust.Shared.GameStates;
 using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
+using Robust.Shared.Timing;
 
 namespace Content.Shared.Backmen.Surgery.Wounds.Systems;
 
@@ -27,6 +28,8 @@ public abstract partial class WoundSystem : EntitySystem
 {
     [Dependency] protected readonly IRobustRandom Random = default!;
     [Dependency] protected readonly IConfigurationManager Cfg = default!;
+
+    [Dependency] protected readonly IGameTiming Timing = default!;
 
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;

--- a/Content.Shared/Mobs/Systems/MobStateSystem.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.cs
@@ -43,6 +43,21 @@ public partial class MobStateSystem : EntitySystem
         return component.CurrentState == MobState.Alive;
     }
 
+    // backmen edit
+    /// <summary>
+    ///  Check if a Mob is Critical. ACTUALLY critical
+    /// </summary>
+    /// <param name="target">Target Entity</param>
+    /// <param name="component">The MobState component owned by the target</param>
+    /// <returns>If the entity is Critical</returns>
+    public bool IsHardCritical(EntityUid target, MobStateComponent? component = null)
+    {
+        if (!_mobStateQuery.Resolve(target, ref component, false))
+            return false;
+        return component.CurrentState is MobState.Critical;
+    }
+    // backmen edit
+
     /// <summary>
     ///  Check if a Mob is Critical
     /// </summary>

--- a/Resources/Prototypes/Damage/types.yml
+++ b/Resources/Prototypes/Damage/types.yml
@@ -99,3 +99,4 @@
   name: damage-type-holy
   armorCoefficientPrice: 1
   armorFlatPrice: 1
+  woundHealingMultiplier: 5

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -98,6 +98,12 @@
         - MobMask
         layer:
         - MobLayer
+  - type: MobState
+    allowedStates:
+    - Alive
+    - SoftCritical
+    - Critical
+    - Dead
   - type: FloorOcclusion
   - type: Mood
   - type: RangedDamageSound

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -97,7 +97,6 @@
   - type: MobState
     allowedStates:
     - Alive
-    - SoftCritical
     - Critical
     - Dead
   - type: MobThresholds

--- a/Resources/Prototypes/_Backmen/Entities/Surgery/wounds.yml
+++ b/Resources/Prototypes/_Backmen/Entities/Surgery/wounds.yml
@@ -163,7 +163,7 @@
     scarWound: BurnScar
     integrityMultiplier: 0.34 # boiling people
   - type: TraumaInflicter
-    severityThreshold: 17
+    severityThreshold: 24
     allowedTraumas:
     - OrganDamage
     - BoneDamage
@@ -224,7 +224,7 @@
     woundType: Internal
     woundVisibility: AdvancedScanner
     scarWound: BurnScar
-    integrityMultiplier: 0.6
+    integrityMultiplier: 0.34
   - type: TraumaInflicter
     severityThreshold: 0
     allowedTraumas:
@@ -252,7 +252,7 @@
     woundType: Internal
     woundVisibility: AdvancedScanner
     scarWound: BurnScar
-    integrityMultiplier: 0.34
+    integrityMultiplier: 0 # Rotting does not gib people
   - type: TraumaInflicter
     severityThreshold: 12
     allowedTraumas:
@@ -334,16 +334,6 @@
     woundType: Internal
     woundVisibility: AdvancedScanner
     integrityMultiplier: 0
-  - type: TraumaInflicter
-    severityThreshold: 0
-    allowedTraumas:
-    - NerveDamage
-    traumasChances:
-      Dismemberment: 0
-      OrganDamage: 0
-      BoneDamage: 0
-      VeinsDamage: 0
-      NerveDamage: 0.777
   - type: PainInflicter
     painType: TraumaticPain
     multiplier: 0.333

--- a/Resources/Prototypes/_White/themes.yml
+++ b/Resources/Prototypes/_White/themes.yml
@@ -14,3 +14,4 @@
     disabledFore: "#5A5A5A"
     _itemstatus_content_margin_right: "#06060604"
     _itemstatus_content_margin_left: "#06060604"
+    _itemstatus_patch_margin: "#07060404"


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [x] Tweak
- [ ] Balance
- [ ] Refactor
- [ ] Port
- [ ] Translate
- [ ] Resprite

- fix: Ispravleno mnogo vsyakoy vsyachini, svyazannoy s rebellom!!!



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Новые возможности**
	- Добавлен новый цветовой параметр для темы интерфейса.
	- В компонент ранений добавлены параметры для отслеживания времени последнего повреждения и задержки перед заживлением.
	- В систему состояний мобов добавлен метод для определения состояния "жёсткой критичности".
	- Для типа урона "Святой" добавлен множитель ускоренного заживления ран.

- **Исправления ошибок**
	- Исправлено поведение уведомлений при попытке проведения сердечно-легочной реанимации (СЛР).
	- Исправлено удаление положительных модификаторов удушья при изменении состояния сознания.

- **Изменения баланса**
	- Изменены параметры тяжести и влияния некоторых типов ран (тепловые, клеточные, гнилостные, святые).
	- Удалено наложение травм нервов для "Святого" типа ран.
	- Изменена логика оценки критического состояния целей NPC — теперь учитывается только "жёсткая критичность".
	- В базовых сущностях мобов скорректированы разрешённые состояния (убрано "мягкое критическое").

- **Рефакторинг**
	- Оптимизирована логика заживления ран с учётом задержки после последнего повреждения.
	- Обновлены коллекции для отслеживания органов, затронутых СЛР, для повышения производительности.

- **Технические улучшения**
	- В систему ран внедрена зависимость для работы с игровым временем.
	- Удалена устаревшая логика модификации сознания при удушье.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->