### PR TITLE
KRUTOY! hotfix

### DIFF
--- a/Content.IntegrationTests/Tests/CargoTest.cs
+++ b/Content.IntegrationTests/Tests/CargoTest.cs
@@ -21,7 +21,7 @@ public sealed class CargoTest
     private static readonly HashSet<ProtoId<CargoProductPrototype>> Ignored =
     [
         // This is ignored because it is explicitly intended to be able to sell for more than it costs.
-        //new("FunCrateGambling")
+        new("FunCrateGambling"),
     ];
 
     [Test]

--- a/Content.Server/Audio/Jukebox/JukeboxSystem.cs
+++ b/Content.Server/Audio/Jukebox/JukeboxSystem.cs
@@ -93,6 +93,7 @@ public sealed class JukeboxSystem : SharedJukeboxSystem
         DirectSetVisualState(uid, JukeboxVisualState.Select);
         component.Selecting = true;
         Stop((uid, component));
+        Dirty(uid, component);
     }
 
     public override void Update(float frameTime)

--- a/Content.Server/Backmen/Administration/Commands/Toolshed/AddDiseaseCommand.cs
+++ b/Content.Server/Backmen/Administration/Commands/Toolshed/AddDiseaseCommand.cs
@@ -33,5 +33,7 @@ public sealed class AddDiseaseCommand : ToolshedCommand
         [PipedArgument] IEnumerable<EntityUid> input,
         [CommandArgument] ProtoId<DiseasePrototype> prototype
     )
-        => input.Select(x => AddDisease(x, prototype)).Where(x => x is not null).Select(x => (EntityUid) x!);
+    {
+        return input.Select(x => AddDisease(x, prototype)).Where(x => x is not null).Select(x => (EntityUid)x!);
+    }
 }

--- a/Content.Server/Backmen/Administration/Commands/Toolshed/ChangeTTSCommand.cs
+++ b/Content.Server/Backmen/Administration/Commands/Toolshed/ChangeTTSCommand.cs
@@ -20,7 +20,6 @@ public sealed class ChangeTTSCommand : ToolshedCommand
 
     [CommandImplementation]
     public EntityUid? ChangeTTS(
-        [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid input,
         [CommandArgument] ProtoId<TTSVoicePrototype> prototype
     )
@@ -41,9 +40,8 @@ public sealed class ChangeTTSCommand : ToolshedCommand
 
     [CommandImplementation]
     public IEnumerable<EntityUid> ChangeTTS(
-        [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] IEnumerable<EntityUid> input,
         [CommandArgument] ProtoId<TTSVoicePrototype> prototype
     )
-        => input.Select(x => ChangeTTS(ctx, x, prototype)).Where(x => x is not null).Select(x => (EntityUid) x!);
+        => input.Select(x => ChangeTTS(x, prototype)).Where(x => x is not null).Select(x => (EntityUid) x!);
 }

--- a/Content.Server/Backmen/Surgery/Pain/Systems/ServerPainSystem.cs
+++ b/Content.Server/Backmen/Surgery/Pain/Systems/ServerPainSystem.cs
@@ -326,7 +326,8 @@ public sealed class ServerPainSystem : PainSystem
                 nerveSys.Value,
                 args.Component.HoldingWoundable,
                 PainTraumaticModifierIdentifier,
-                traumaticPain);
+                traumaticPain,
+                painType: PainType.TraumaticPain);
         }
     }
 

--- a/Content.Shared/Backmen/Surgery/Traumas/Systems/TraumaSystem.Process.cs
+++ b/Content.Shared/Backmen/Surgery/Traumas/Systems/TraumaSystem.Process.cs
@@ -381,40 +381,17 @@ public partial class TraumaSystem
         return Random.Prob((float) chance);
     }
 
+    /// <summary>
+    /// Soon to be removed
+    /// </summary>
+    [Obsolete]
     [PublicAPI]
-    public bool RandomNerveDamageChance(
+    private bool RandomNerveDamageChance(
         Entity<WoundableComponent> target,
         Entity<TraumaInflicterComponent> woundInflicter)
     {
-        var bodyPart = Comp<BodyPartComponent>(target);
-        if (!bodyPart.Body.HasValue)
-            return false; // No entity to apply pain to
-
-        if (!TryComp<NerveComponent>(target, out var nerve))
-            return false;
-
-        if (nerve.PainFeels < _nerveDamageThreshold)
-            return false;
-
-        var deduction = GetTraumaChanceDeduction(
-            woundInflicter,
-            bodyPart.Body.Value,
-            target,
-            Comp<WoundComponent>(woundInflicter).WoundSeverityPoint,
-            TraumaType.NerveDamage,
-            bodyPart.PartType);
-
-        // literally dismemberment chance, but lower by default
-        var chance =
-            FixedPoint2.Clamp(
-                target.Comp.WoundableIntegrity / target.Comp.IntegrityCap / 20
-                - deduction
-                + woundInflicter.Comp.TraumasChances[TraumaType.NerveDamage]
-                + target.Comp.PassiveTraumaChances[TraumaType.NerveDamage],
-                0,
-                1);
-
-        return Random.Prob((float) chance);
+        // no fuck you
+        return false;
     }
 
     [PublicAPI]

--- a/Content.Shared/Stunnable/SharedStunSystem.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.cs
@@ -34,7 +34,7 @@ public abstract class SharedStunSystem : EntitySystem
     [Dependency] private readonly EntityWhitelistSystem _entityWhitelist = default!;
     [Dependency] private readonly StandingStateSystem _standingState = default!;
     [Dependency] private readonly StatusEffectsSystem _statusEffect = default!;
-    [Dependency] private readonly SharedLayingDownSystem _layingDown = default!; // Ataraxia EDIT
+    [Dependency] private readonly SharedLayingDownSystem _layingDown = default!; // Backmen edit
 
     /// <summary>
     /// Friction modifier for knocked down players.
@@ -134,31 +134,19 @@ public abstract class SharedStunSystem : EntitySystem
     private void OnKnockInit(EntityUid uid, KnockedDownComponent component, ComponentInit args)
     {
         _standingState.Down(uid);
-        // start-backmen: Laying System
-        if (TryComp<LayingDownComponent>(uid, out var layingDownComponent))
-        {
-            _layingDown.TryProcessAutoGetUp((uid, layingDownComponent));
-            _layingDown.TryLieDown(uid, layingDownComponent, null, DropHeldItemsBehavior.DropIfStanding); // Ataraxia EDIT
-        }
-        // end-backmen: Laying System
-
     }
-
 
     private void OnKnockShutdown(EntityUid uid, KnockedDownComponent component, ComponentShutdown args)
     {
         // start-backmen: Laying System
-        if (!TryComp(uid, out StandingStateComponent? standing))
-            return;
-
         if (TryComp(uid, out LayingDownComponent? layingDown))
         {
             _layingDown.TryProcessAutoGetUp((uid,layingDown));
             return;
         }
-
-        _standingState.Stand(uid, standing);
         // end-backmen: Laying System
+
+        _standingState.Stand(uid);
     }
 
     private void OnStandAttempt(EntityUid uid, KnockedDownComponent component, StandAttemptEvent args)

--- a/Resources/Locale/ru-RU/power/teg.ftl
+++ b/Resources/Locale/ru-RU/power/teg.ftl
@@ -1,2 +1,3 @@
 teg-generator-examine-power = Он генерирует [color=yellow]{ POWERWATTS($power) }[/color].
+teg-generator-examine-power-max-output = It's capable of supplying [color=yellow]{ POWERWATTS($power) }[/color].
 teg-generator-examine-connection = Для функционирования [color=white]циркуляционные насосы[/color] должен быть подключены с обеих сторон.

--- a/Resources/Locale/ru-RU/power/teg.ftl
+++ b/Resources/Locale/ru-RU/power/teg.ftl
@@ -1,3 +1,3 @@
 teg-generator-examine-power = Он генерирует [color=yellow]{ POWERWATTS($power) }[/color].
-teg-generator-examine-power-max-output = It's capable of supplying [color=yellow]{ POWERWATTS($power) }[/color].
+teg-generator-examine-power-max-output = Он способен поставлять [color=yellow]{ POWERWATTS($power) }[/color].
 teg-generator-examine-connection = Для функционирования [color=white]циркуляционные насосы[/color] должен быть подключены с обеих сторон.

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
@@ -18,7 +18,7 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.49,-0.49,0.49,-0.36"
+          bounds: "-0.49,-0.49,0.49,-0.42"
         density: 1500
         mask:
         - TabletopMachineMask

--- a/Resources/Prototypes/_Backmen/Entities/Surgery/wounds.yml
+++ b/Resources/Prototypes/_Backmen/Entities/Surgery/wounds.yml
@@ -20,7 +20,7 @@
     woundType: External
     woundVisibility: Always
     scarWound: BluntScar
-    integrityMultiplier: 1 #heheheha
+    integrityMultiplier: 0.3 #heheheha
   - type: TraumaInflicter
     severityThreshold: 12
     allowedTraumas:
@@ -57,7 +57,7 @@
     woundType: External
     woundVisibility: Always
     scarWound: PiercingScar
-    integrityMultiplier: 0.25
+    integrityMultiplier: 0.12
   - type: TraumaInflicter
     severityThreshold: 12
     allowedTraumas:
@@ -93,7 +93,7 @@
     woundType: External
     woundVisibility: Always
     scarWound: PiercingScar
-    integrityMultiplier: 0.44
+    integrityMultiplier: 0.05
   - type: TraumaInflicter
     severityThreshold: 6
     allowedTraumas:
@@ -126,7 +126,7 @@
     woundType: External
     woundVisibility: Always
     scarWound: SlashScar
-    integrityMultiplier: 0.25
+    integrityMultiplier: 0.17
   - type: TraumaInflicter
     severityThreshold: 9
     allowedTraumas:
@@ -161,7 +161,7 @@
     woundType: External
     woundVisibility: Always
     scarWound: BurnScar
-    integrityMultiplier: 0.34 # boiling people
+    integrityMultiplier: 0.21 # boiling people
   - type: TraumaInflicter
     severityThreshold: 24
     allowedTraumas:
@@ -224,7 +224,7 @@
     woundType: Internal
     woundVisibility: AdvancedScanner
     scarWound: BurnScar
-    integrityMultiplier: 0.34
+    integrityMultiplier: 0.1
   - type: TraumaInflicter
     severityThreshold: 0
     allowedTraumas:
@@ -278,7 +278,7 @@
     woundType: Internal
     woundVisibility: HandScanner
     scarWound: RadiationScar
-    integrityMultiplier: 0.12
+    integrityMultiplier: 0.06
   - type: TraumaInflicter
     severityThreshold: 11
     allowedTraumas:
@@ -348,7 +348,7 @@
     woundType: Internal
     woundVisibility: HandScanner
     scarWound: BurnScar
-    integrityMultiplier: 0.12
+    integrityMultiplier: 0.07
   - type: TraumaInflicter
     severityThreshold: 9
     allowedTraumas:

--- a/Resources/Prototypes/_Backmen/GameRules/events.yml
+++ b/Resources/Prototypes/_Backmen/GameRules/events.yml
@@ -159,6 +159,11 @@
       glimmerBurnLower: 18
       glimmerBurnUpper: 40
     - type: PsionicCatGotYourTongueRule
+    - type: StationEvent
+      weight: 12
+      earliestStart: 30
+      reoccurrenceDelay: 20
+      minimumPlayers: 20
 
 - type: entity
   id: MassMindSwap
@@ -329,7 +334,7 @@
       startAnnouncement: station-event-vent-creatures-start-announcement
       startAudio:
         path: /Audio/Announcements/attention.ogg
-      minimumPlayers: 15
+      minimumPlayers: 25
       earliestStart: 30
       reoccurrenceDelay: 50
       weight: 6
@@ -352,7 +357,7 @@
       path: /Audio/Effects/metal_break1.ogg
     weight: 6
     duration: 1
-    minimumPlayers: 15
+    minimumPlayers: 25
     earliestStart: 30
     reoccurrenceDelay: 50
   - type: RandomSpawnRule


### PR DESCRIPTION
[ ] Feature
[x] Fix
[x] Tweak
[ ] Balance
[ ] Refactor
[ ] Port
[ ] Translate
[ ] Resprite

:cl:
remove: Ybrana RANDOMNAYA BOL iz rebella, v chest pererabotki travm! yra!
tweak: Nemnogo izmeneni parametri yrona po chastyam tela ot woundov
fix: Zvukopodavlenie boomboxov okazalos slischkom effektivnim

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Изменения баланса**
  * Значительно снижены множители прочности для различных типов ран (тупая, колющая, бронебойная, режущая, тепловая, клеточная, радиационная, шоковая), что уменьшает их влияние на целостность сущностей.
  * Отключён случайный шанс повреждения нервов при травмах.

* **Улучшения интерфейса и визуализации**
  * Обновлены методы управления визуальными свойствами спрайтов при смене положения персонажа (стоя/лежа), обеспечено более централизованное управление через систему спрайтов.

* **Рефакторинг**
  * Улучшена читаемость и структурированность кода систем стояния и лежания: выделена логика проверки наличия ног, переименованы методы для большей ясности, инвертированы некоторые условия для повышения читаемости.
  * Упрощена обработка событий оглушения и восстановления стояния.
  * Переработаны и перемещены методы для автоподъёма персонажа.

* **Исправления**
  * Скорректирована логика инициализации и завершения оглушения для корректного восстановления стояния.

* **Тесты**
  * В тестах игнорируется продукт "FunCrateGambling" при проверке на арбитраж заказов.

* **Прочее**
  * Незначительно изменена форма коллизии у базовой стеклянной двери для корректной физики.
  * Добавлена новая строка локализации для отображения максимальной мощности генератора.
  * Обновлены параметры минимального количества игроков и расписания для некоторых игровых событий.
  * Улучшена проверка SSL-сертификатов для внутренних HTTP-запросов.
  * Упрощён вызов команд для изменения голосового движка TTS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->