### PR TITLE
Hotfix 230126 2

### DIFF
--- a/Content.Server/Backmen/Abilities/Psionics/Abilities/MetapsionicPowerSystem.cs
+++ b/Content.Server/Backmen/Abilities/Psionics/Abilities/MetapsionicPowerSystem.cs
@@ -68,7 +68,7 @@ public sealed class MetapsionicPowerSystem : EntitySystem
             psionic.PsionicAbility = component.MetapsionicPowerAction;
     }
 
-    private static readonly EntProtoId MetapsionicVisibleStatus = "MetapsionicVisible";
+    private static readonly EntProtoId MetapsionicVisibleStatus = "StatusEffectPsionicAllSee";
 
     private void OnPowerUsed(EntityUid uid, MetapsionicPowerComponent component, MetapsionicPowerActionEvent args)
     {

--- a/Content.Server/Backmen/Abilities/Psionics/PsionicAbilitiesSystem.cs
+++ b/Content.Server/Backmen/Abilities/Psionics/PsionicAbilitiesSystem.cs
@@ -10,7 +10,7 @@ using Content.Shared.Backmen.Abilities.Psionics;
 using Content.Shared.Backmen.Psionics;
 using Content.Shared.Interaction;
 using Content.Shared.Physics;
-using Content.Shared.StatusEffect;
+using Content.Shared.StatusEffectNew;
 using Robust.Shared.Random;
 using Robust.Shared.Prototypes;
 using Robust.Server.Player;
@@ -129,7 +129,7 @@ public sealed class PsionicAbilitiesSystem : SharedPsionicAbilitiesSystem
             _actionsSystem.RemoveAction(uid, psionic.PsionicAbility);
 
         if(!noEffect)
-            _statusEffectsSystem.TryAddStatusEffect(uid, "Stutter", TimeSpan.FromMinutes(5), false, "StutteringAccent");
+            _statusEffectsSystem.TryAddStatusEffectDuration(uid, "StatusEffectStutter", TimeSpan.FromMinutes(5));
 
         RemCompDeferred<PsionicComponent>(uid);
     }

--- a/Content.Server/Backmen/Psionics/Invisbility/PsionicInvisibilitySystem.cs
+++ b/Content.Server/Backmen/Psionics/Invisbility/PsionicInvisibilitySystem.cs
@@ -29,6 +29,7 @@ public sealed class PsionicInvisibilitySystem : EntitySystem
 
         // Visibility mask event
         SubscribeLocalEvent<GetVisMaskEvent>(OnGetVisMask);
+        SubscribeLocalEvent<PsionicallyInvisibleComponent, GetVisMaskEvent>(OnGetVisMask2);
 
         // Layer
         SubscribeLocalEvent<PsionicallyInvisibleComponent, ComponentInit>(OnInvisInit);
@@ -37,6 +38,14 @@ public sealed class PsionicInvisibilitySystem : EntitySystem
         // PVS Stuff
         SubscribeLocalEvent<PsionicallyInvisibleComponent, EntInsertedIntoContainerMessage>(OnEntInserted);
         SubscribeLocalEvent<PsionicallyInvisibleComponent, EntRemovedFromContainerMessage>(OnEntRemoved);
+    }
+
+    private void OnGetVisMask2(Entity<PsionicallyInvisibleComponent> ent, ref GetVisMaskEvent args)
+    {
+        if (ent.Comp.LifeStage > ComponentLifeStage.Running)
+            return;
+
+        args.VisibilityMask |= (int)VisibilityFlags.PsionicInvisibility;
     }
 
     private void OnGetVisMask(ref GetVisMaskEvent args)
@@ -48,7 +57,8 @@ public sealed class PsionicInvisibilitySystem : EntitySystem
         }
 
         // Entities with PsionicInsulationComponent can see psionic invisibility
-        if (HasComp<PsionicInsulationComponent>(args.Entity))
+        if (TryComp<PsionicInsulationComponent>(args.Entity, out var insulationComponent)
+            && insulationComponent.LifeStage <= ComponentLifeStage.Running)
         {
             args.VisibilityMask |= (int)VisibilityFlags.PsionicInvisibility;
             return;

--- a/Content.Server/Backmen/Species/Shadowkin/Systems/ShadowkinPowerSystem.DarkSwap.cs
+++ b/Content.Server/Backmen/Species/Shadowkin/Systems/ShadowkinPowerSystem.DarkSwap.cs
@@ -76,6 +76,9 @@ public sealed class ShadowkinDarkSwapSystem : EntitySystem
 
     private void OnGetVisMask(Entity<ShadowkinDarkSwappedComponent> ent, ref GetVisMaskEvent args)
     {
+        if (ent.Comp.LifeStage > ComponentLifeStage.Running)
+            return;
+
         // Entities with ShadowkinDarkSwappedComponent can see DarkSwapped entities
         args.VisibilityMask |= (int)VisibilityFlags.DarkSwapInvisibility;
     }

--- a/Content.Server/Backmen/Speech/EntitySystems/ShadowkinAccentSystem.cs
+++ b/Content.Server/Backmen/Speech/EntitySystems/ShadowkinAccentSystem.cs
@@ -34,20 +34,20 @@ public sealed class ShadowkinAccentSystem : EntitySystem
         {
             var current = c.ToString();
 
-            // Английские замены (шанс 30%)
-            if (_random.Prob(0.3f) && mRegex.IsMatch(current))
+            // Английские замены (шанс 10%)
+            if (_random.Prob(0.1f) && mRegex.IsMatch(current))
                 current = "m";
-            if (_random.Prob(0.3f) && aRegex.IsMatch(current))
+            if (_random.Prob(0.1f) && aRegex.IsMatch(current))
                 current = "a";
             if (_random.Prob(0.1f) && rRegex.IsMatch(current))
                 current = "r";
 
-            // Русские замены (шанс 30%)
-            if (_random.Prob(0.3f) && mRegexRu.IsMatch(current))
+            // Русские замены (шанс 10%)
+            if (_random.Prob(0.1f) && mRegexRu.IsMatch(current))
                 current = "м";
-            if (_random.Prob(0.3f) && aRegexRu.IsMatch(current))
+            if (_random.Prob(0.1f) && aRegexRu.IsMatch(current))
                 current = "а";
-            if (_random.Prob(0.3f) && rRegexRu.IsMatch(current))
+            if (_random.Prob(0.1f) && rRegexRu.IsMatch(current))
                 current = "р";
 
             result.Append(current);

--- a/Content.Server/_Lavaland/Procedural/Systems/LavalandPlanetSystem.Grid.cs
+++ b/Content.Server/_Lavaland/Procedural/Systems/LavalandPlanetSystem.Grid.cs
@@ -164,13 +164,13 @@ public sealed partial class LavalandPlanetSystem
                             if (_map.TryGetTileRef(sourceGridUid, sourceGrid, offsetTile, out var lavalandTile) &&
                                 !lavalandTile.Tile.IsEmpty)
                             {
-                                _map.SetTile(spawned.Value, spawnedGrid, offsetTile, lavalandTile.Tile);
+                                _map.SetTile(spawned.Value, spawnedGrid, tileRef.Value.GridIndices, lavalandTile.Tile);
                             }
                         }
                     }
 
                     _gridFixture.Merge(sourceGridUid, spawned.Value, matrix);
-                    
+
                     foreach (var vector2I in tilesToRoof)
                     {
                         _roofSystem.SetRoof(roofMap, vector2I, true);

--- a/Content.Shared/Backmen/Abilities/Psionics/Abilities/MassSleep/MassSleepPowerSystem.cs
+++ b/Content.Shared/Backmen/Abilities/Psionics/Abilities/MassSleep/MassSleepPowerSystem.cs
@@ -14,7 +14,7 @@ public sealed class MassSleepPowerSystem : EntitySystem
     [Dependency] private readonly SharedActionsSystem _actions = default!;
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly SharedPsionicAbilitiesSystem _psionics = default!;
-    [Dependency] private readonly SleepingSystem _sleepingSystem = default!;
+    [Dependency] private readonly StatusEffectNew.StatusEffectsSystem _effectsSystem = default!;
     private EntityQuery<PsionicInsulationComponent> _qPsionicInsulation;
 
     public override void Initialize()
@@ -68,7 +68,7 @@ public sealed class MassSleepPowerSystem : EntitySystem
             if (!TryComp<DamageableComponent>(entity, out var damageable) || damageable.DamageContainerID != Biological)
                 continue;
 
-            var result = _sleepingSystem.TrySleeping((entity.Owner,entity.Comp));
+            var result = _effectsSystem.TryUpdateStatusEffectDuration(entity, "StatusEffectForcedSleeping", TimeSpan.FromSeconds(10));
             if (!handle && result)
                 handle = true;
         }

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -357,7 +357,6 @@
     - id: CargoRequestSecurityComputerCircuitboard
     # backmen edit end
     - id: WeaponDisabler
-    - id: WeaponTaser
     - id: WantedListCartridge
     - id: DrinkHosFlask
     # Corvax-Start

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -29,7 +29,6 @@
     - id: FlashlightSeclite
     - id: WeaponDisabler
       prob: 0.3  # backmen edit: шанс на дисаблер
-    - id: WeaponTaser
     - id: ClothingBeltSecurityFilled
     - id: Flash
     - id: ClothingEyesGlassesSecurity
@@ -84,7 +83,6 @@
     - id: FlashlightSeclite
       prob: 0.8
     - id: WeaponDisabler
-    - id: WeaponTaser
     - id: ClothingUniformJumpsuitSecGrey
       prob: 0.3
     - id: ClothingHeadHelmetBasic
@@ -122,7 +120,6 @@
   table: !type:AllSelector
     children:
     - id: ClothingEyesGlassesSecurity
-    - id: WeaponTaser
     - id: WeaponDisabler
     - id: TrackingImplanter
       amount: 2

--- a/Resources/Prototypes/_Backmen/Entities/Objects/Weapons/Grenades/smoke.yml
+++ b/Resources/Prototypes/_Backmen/Entities/Objects/Weapons/Grenades/smoke.yml
@@ -29,6 +29,17 @@
   - type: DeleteOnTrigger
 
 - type: entity
+  name: psi mine
+  parent: LandMinePsi
+  id: LandMinePsiArmed
+  suffix: armed
+  components:
+  - type: ItemToggle
+    activated: true
+    onActivate: false
+  - type: Armable
+
+- type: entity
   name: Xeno mine
   parent: BaseLandMine
   id: LandMineXeno

--- a/Resources/Prototypes/_Backmen/StatusEffects/psionics.yml
+++ b/Resources/Prototypes/_Backmen/StatusEffects/psionics.yml
@@ -11,3 +11,11 @@
   name: psionic disabled
   components:
   - type: PsionicsDisabled
+
+
+- type: entity
+  parent: MobStatusEffectBase
+  id: StatusEffectPsionicAllSee
+  name: psionic all see
+  components:
+  - type: MetapsionicVisible


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Примечания к выпуску

* **Исправления ошибок**
  * Исправлена укладка плит лавалэнда при процедурной генерации.
  * Упрощена и исправлена логика видимости псионических эффектов и тёмного обмена.

* **Изменения баланса**
  * Снижена частота подстановок акцента в речи персонажа (30% → 10%).
  * Удалены электрошокеры из наборов экипировки охраны.

* **Новые функции**
  * Добавлен вариант вооружённой псионической мины.
  * Введён новый статус видимости для метапсионики.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->