### PR TITLE
ReBELL Act 3 Patch I

### DIFF
--- a/Content.Client/Backmen/Surgery/Wounds/WoundableVisualsSystem.cs
+++ b/Content.Client/Backmen/Surgery/Wounds/WoundableVisualsSystem.cs
@@ -18,6 +18,8 @@ public sealed partial class WoundableVisualsSystem : VisualizerSystem<WoundableV
     [Dependency] private BkmBodySharedSystem _body = default!;
     [Dependency] private WoundSystem _wound = default!;
 
+    [Dependency] private SpriteSystem _sprite = default!;
+
     [Dependency] private IRobustRandom _random = default!;
 
     private const float AltBleedingSpriteChance = 0.15f;
@@ -29,8 +31,8 @@ public sealed partial class WoundableVisualsSystem : VisualizerSystem<WoundableV
         SubscribeLocalEvent<WoundableVisualsComponent, ComponentInit>(InitializeEntity, after: [typeof(WoundSystem)]);
         SubscribeLocalEvent<WoundableVisualsComponent, ComponentStartup>(StartupEntity, after: [typeof(WoundSystem)]);
 
-        SubscribeLocalEvent<WoundableVisualsComponent, BodyPartRemovedEvent>(WoundableRemoved);
-        SubscribeLocalEvent<WoundableVisualsComponent, BodyPartAddedEvent>(WoundableConnected);
+        SubscribeLocalEvent<BodyComponent, BodyPartRemovedEvent>(WoundableRemoved);
+        SubscribeLocalEvent<BodyComponent, BodyPartAddedEvent>(WoundableConnected);
 
         SubscribeLocalEvent<WoundableVisualsComponent, WoundableIntegrityChangedEvent>(OnWoundableIntegrityChanged);
     }
@@ -73,41 +75,52 @@ public sealed partial class WoundableVisualsSystem : VisualizerSystem<WoundableV
         UpdateWoundableVisuals(uid, component, bodySprite);
     }
 
-    private void WoundableConnected(EntityUid uid, WoundableVisualsComponent component, ref BodyPartAddedEvent args)
+    private void WoundableConnected(EntityUid uid, BodyComponent component, ref BodyPartAddedEvent args)
     {
-        if (!TryComp(args.Part.Comp.Body, out SpriteComponent? bodySprite))
+        //if (!component.ComplexBody)
+        //    return;
+
+        if (!TryComp(uid, out SpriteComponent? bodySprite)
+            || !TryComp(args.Part, out WoundableVisualsComponent? visuals))
             return;
 
-        EnsureDamageLayersOnSprite(component, bodySprite);
+        EnsureDamageLayersOnSprite(visuals, bodySprite);
     }
 
-    private void WoundableRemoved(EntityUid uid, WoundableVisualsComponent component, ref BodyPartRemovedEvent args)
+    // TODO: redo this
+    private void WoundableRemoved(EntityUid uid, BodyComponent component, ref BodyPartRemovedEvent args)
     {
-        var body = args.Part.Comp.Body;
-        if (!TryComp(body, out SpriteComponent? bodySprite))
+        // TODO: derive bodies by complexness
+        //if (!component.ComplexBody)
+        //    return;
+
+        if (!TryComp(uid, out SpriteComponent? bodySprite))
             return;
 
-        foreach (var part in _body.GetBodyPartChildren(uid))
+        var removedPart = args.Part;
+
+        Entity<SpriteComponent?> bodyEnt = (uid, bodySprite);
+        foreach (var part in _body.GetBodyPartChildren(removedPart))
         {
             if (!TryComp<WoundableVisualsComponent>(part.Id, out var woundableVisuals))
                 continue;
 
             foreach (var (group, _) in woundableVisuals.DamageOverlayGroups!)
             {
-                if (!bodySprite.LayerMapTryGet($"{woundableVisuals.OccupiedLayer}{group}", out var layer))
+                if (!_sprite.LayerMapTryGet(bodyEnt, $"{woundableVisuals.OccupiedLayer}{group}", out var layer, false))
                     continue;
 
-                bodySprite.LayerSetVisible(layer, false);
-                bodySprite.LayerMapRemove(layer);
+                _sprite.LayerSetVisible(bodyEnt, layer, false);
+                _sprite.RemoveLayer(bodyEnt, layer);
             }
 
-            if (bodySprite.LayerMapTryGet($"{woundableVisuals.OccupiedLayer}Bleeding", out var childBleeds))
+            if (_sprite.LayerMapTryGet(bodyEnt, $"{woundableVisuals.OccupiedLayer}Bleeding", out var childBleeds, false))
             {
-                bodySprite.LayerSetVisible(childBleeds, false);
-                bodySprite.LayerMapRemove(childBleeds);
+                _sprite.LayerSetVisible(bodyEnt, childBleeds, false);
+                _sprite.RemoveLayer(bodyEnt, childBleeds);
             }
 
-            if (TryComp(uid, out SpriteComponent? pieceSprite))
+            if (TryComp(part.Id, out SpriteComponent? pieceSprite))
                 UpdateWoundableVisuals(part.Id, woundableVisuals, pieceSprite);
         }
     }

--- a/Content.Server/Backmen/Body/Systems/BkmBurnWoundableSystem.cs
+++ b/Content.Server/Backmen/Body/Systems/BkmBurnWoundableSystem.cs
@@ -11,5 +11,5 @@ public sealed partial class BkmBurnWoundableSystem : EntitySystem
     [Dependency] private WoundSystem _wounds = default!;
 
     public bool ShouldBurnToAsh(EntityUid woundable, WoundableComponent? component = null) =>
-        _wounds.ShouldBurnToAsh(woundable, component);
+        _wounds.ShouldBurnToAsh((woundable, component));
 }

--- a/Content.Server/Backmen/Body/Systems/BkmBurnWoundableSystem.cs
+++ b/Content.Server/Backmen/Body/Systems/BkmBurnWoundableSystem.cs
@@ -11,5 +11,5 @@ public sealed partial class BkmBurnWoundableSystem : EntitySystem
     [Dependency] private WoundSystem _wounds = default!;
 
     public bool ShouldBurnToAsh(EntityUid woundable, WoundableComponent? component = null) =>
-        _wounds.ShouldBurnToAsh((woundable, component));
+        _wounds.ShouldBurnToAshNullable((woundable, component));
 }

--- a/Content.Server/Backmen/Shipwrecked/ShipwreckedRuleSystem.cs
+++ b/Content.Server/Backmen/Shipwrecked/ShipwreckedRuleSystem.cs
@@ -1355,7 +1355,7 @@ public sealed partial class ShipwreckedRuleSystem : GameRuleSystem<ShipwreckedRu
             false,
             true,
             Color.SeaGreen);
-        
+
         var announcementEv = new AnnouncementSpokeEvent(filter, _audioSystem.GetSound(ChatSystem.DefaultAnnouncementSound), AudioParams.Default.WithVolume(-2f), message);
         RaiseLocalEvent(announcementEv);
         //var audioPath = _audioSystem.GetSound(audio);

--- a/Content.Server/Backmen/Surgery/Wounds/Systems/ServerWoundSystem.cs
+++ b/Content.Server/Backmen/Surgery/Wounds/Systems/ServerWoundSystem.cs
@@ -76,7 +76,9 @@ public sealed partial class ServerWoundSystem : WoundSystem
 
             woundable.HealingRateAccumulated -= timeToHeal;
 
-            var bleedWounds = GetWoundableWoundsWithComp<BleedInflicterComponent>(ent, woundable).ToArray();
+            Entity<WoundableComponent> owner = (ent, woundable);
+            var bleedWounds =
+                GetWoundableWoundsWithComp<BleedInflicterComponent>(owner).ToArray();
             var bleedingAmount = bleedWounds.Aggregate(FixedPoint2.Zero,
                     (current, wound) => current + wound.Comp2.BleedingAmount);
 
@@ -93,7 +95,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
                 continue;
 
             var woundsToHeal =
-                GetWoundableWounds(ent, woundable)
+                GetWoundableWounds(owner)
                     .Where(wound => CanHealWound(wound, wound))
                     .Where(wound => wound.Comp.DamagedLastTime + wound.Comp.CanHealAfter < Timing.CurTime)
                     .ToArray();
@@ -102,12 +104,10 @@ public sealed partial class ServerWoundSystem : WoundSystem
                 continue;
 
             var healAmount = -woundable.HealAbility / woundsToHeal.Length;
-
-            Entity<WoundableComponent> owner = (ent, woundable);
             foreach (var x in woundsToHeal)
             {
-                ApplyWoundSeverity(x.AsNullable(),
-                    ApplyHealingRateMultipliers((x,x), owner, healAmount, owner));
+                ApplyWoundSeverity(x,
+                    ApplyHealingRateMultipliersNullable((x, x), owner, healAmount, owner));
             }
         }
     }
@@ -211,15 +211,15 @@ public sealed partial class ServerWoundSystem : WoundSystem
             return false;
 
         var proto = _prototype.Index(id);
-        foreach (var wound in GetWoundableWounds(uid, woundable))
+        foreach (var wound in GetWoundableWounds((uid, woundable)))
         {
             if (proto.ID != wound.Comp.DamageType)
                 continue;
 
-            if (!RollForWoundMerging(wound.AsNullable(), severity))
+            if (!RollForWoundMerging(wound, severity))
                 continue;
 
-            ApplyWoundSeverity(wound.AsNullable(), severity);
+            ApplyWoundSeverity(wound, severity);
             woundContinued = wound;
 
             return true;
@@ -256,7 +256,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
     }
 
     [PublicAPI]
-    public override void ApplyWoundSeverity(
+    public override void ApplyWoundSeverityNullable(
         Entity<WoundComponent?> woundEnt,
         FixedPoint2 severity)
     {
@@ -270,23 +270,23 @@ public sealed partial class ServerWoundSystem : WoundSystem
 
         var old = wound.WoundSeverityPoint;
         wound.WoundSeverityPoint = severity > 0
-            ? FixedPoint2.Max(FixedPoint2.Zero, old + ApplySeverityModifiers(wound.HoldingWoundable, severity, holdingComp))
+            ? FixedPoint2.Max(FixedPoint2.Zero, old + ApplySeverityModifiers((wound.HoldingWoundable, holdingComp), severity))
             : FixedPoint2.Max(FixedPoint2.Zero, old + severity);
 
         if (wound.WoundSeverityPoint == old)
             return;
 
-        Entity<WoundableComponent?> holdingWoundable = (wound.HoldingWoundable, holdingComp);
+        Entity<WoundableComponent> holdingWoundable = (wound.HoldingWoundable, holdingComp);
 
-        RaiseWoundEvents(woundEnt, holdingWoundable, old);
-        CheckSeverityThresholds(woundEnt);
+        RaiseWoundEvents((uid, wound), holdingWoundable, old);
+        CheckSeverityThresholds((uid, wound));
 
         UpdateWoundableIntegrity(holdingWoundable);
         CheckWoundableSeverityThresholds(holdingWoundable);
     }
 
     [PublicAPI]
-    public override void SetWoundSeverity(
+    public override void SetWoundSeverityNullable(
         Entity<WoundComponent?> woundEnt,
         FixedPoint2 severity)
     {
@@ -301,15 +301,15 @@ public sealed partial class ServerWoundSystem : WoundSystem
 
         var old = wound.WoundSeverityPoint;
         wound.WoundSeverityPoint =
-            FixedPoint2.Max(FixedPoint2.Zero, ApplySeverityModifiers(wound.HoldingWoundable, severity, holdingComp));
+            FixedPoint2.Max(FixedPoint2.Zero, ApplySeverityModifiers((wound.HoldingWoundable, holdingComp), severity));
 
         if (wound.WoundSeverityPoint == old)
             return;
 
-        Entity<WoundableComponent?> holdingWoundable = (wound.HoldingWoundable, holdingComp);
+        Entity<WoundableComponent> holdingWoundable = (wound.HoldingWoundable, holdingComp);
 
-        RaiseWoundEvents(woundEnt, holdingWoundable, old);
-        CheckSeverityThresholds(woundEnt);
+        RaiseWoundEvents((uid, wound), holdingWoundable, old);
+        CheckSeverityThresholds((uid, wound));
 
         UpdateWoundableIntegrity(holdingWoundable);
         CheckWoundableSeverityThresholds(holdingWoundable);
@@ -320,25 +320,26 @@ public sealed partial class ServerWoundSystem : WoundSystem
     #region Severity Multipliers
 
     [PublicAPI]
-    public override bool TryAddWoundableSeverityMultiplier(
+    public override bool TryAddWoundableSeverityMultiplierNullable(
         Entity<WoundableComponent?> woundable,
         EntityUid owner,
         FixedPoint2 change,
         string identifier)
     {
-        if (!WoundableQuery.Resolve(woundable, ref woundable.Comp))
+        var (uid, comp) = woundable;
+        if (!WoundableQuery.Resolve(uid, ref comp))
             return false;
 
-        if (!woundable.Comp.SeverityMultipliers.TryAdd(owner, new WoundableSeverityMultiplier(change, identifier)))
+        if (!comp.SeverityMultipliers.TryAdd(owner, new WoundableSeverityMultiplier(change, identifier)))
             return false;
 
-        foreach (var wound in GetWoundableWounds(woundable))
+        foreach (var wound in GetWoundableWoundsNullable(woundable))
         {
-            CheckSeverityThresholds(wound.AsNullable());
+            CheckSeverityThresholds(wound);
         }
 
-        UpdateWoundableIntegrity(woundable);
-        CheckWoundableSeverityThresholds(woundable);
+        UpdateWoundableIntegrity((uid, comp));
+        CheckWoundableSeverityThresholds((uid, comp));
 
         return true;
     }
@@ -363,10 +364,10 @@ public sealed partial class ServerWoundSystem : WoundSystem
 
             foreach (var wound in component.Wounds.ContainedEntities)
             {
-                CheckSeverityThresholds(wound);
+                CheckSeverityThresholds((wound, Comp<WoundComponent>(wound)));
             }
 
-            Entity<WoundableComponent?> woundable = (uid, component);
+            Entity<WoundableComponent> woundable = (uid, component);
 
             UpdateWoundableIntegrity(woundable);
             CheckWoundableSeverityThresholds(woundable);
@@ -400,10 +401,10 @@ public sealed partial class ServerWoundSystem : WoundSystem
 
             foreach (var wound in component.Wounds.ContainedEntities)
             {
-                CheckSeverityThresholds(wound);
+                CheckSeverityThresholds((wound, Comp<WoundComponent>(wound)));
             }
 
-            Entity<WoundableComponent?> woundable = (uid, component);
+            Entity<WoundableComponent> woundable = (uid, component);
 
             UpdateWoundableIntegrity(woundable);
             CheckWoundableSeverityThresholds(woundable);
@@ -438,6 +439,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
 
     #region Detaching Woundables
 
+    // TODO: REWORK THIS
     [PublicAPI]
     public override void DestroyWoundable(
         EntityUid parentWoundableEntity,
@@ -449,40 +451,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
             || !TryResolveDestroyParent(parentWoundableEntity, ref parentWoundableComp, out parentWoundableEntity))
             return;
 
-        if (!Body.TryGetWoundableBodyPartInfo(woundableEntity, out var bodyUid, out var partType, out _))
-        {
-            if (HasComp<BrainComponent>(woundableEntity))
-            {
-                _brainPreserve.TryPreserveBrain(woundableEntity, Transform(woundableEntity).Coordinates);
-                return;
-            }
-
-            if (_burnWoundable.ShouldBurnToAsh(woundableEntity, woundableComp))
-            {
-                SpawnPartBurnEffects(woundableEntity);
-                QueueDel(woundableEntity);
-                return;
-            }
-
-            DropWoundableOrgans(woundableEntity, woundableComp);
-            QueueDel(woundableEntity);
-
-            return;
-        }
-
-        if (HasComp<BrainComponent>(woundableEntity))
-        {
-            _brainPreserve.TryPreserveBrain(woundableEntity, Transform(woundableEntity).Coordinates);
-            return;
-        }
-
-        if (_burnWoundable.ShouldBurnToAsh(woundableEntity, woundableComp))
-        {
-            BurnWoundableToAsh(parentWoundableEntity, woundableEntity, woundableComp, parentWoundableComp);
-            return;
-        }
-
-        // if wounds amount somehow changes it triggers an enumeration error. owch
+        // if wounds amount somehow changes, it triggers an enumeration error. owch
         woundableComp.AllowWounds = false;
         woundableComp.WoundableSeverity = WoundableSeverity.Loss;
         DirtyFields(woundableEntity, woundableComp, null,
@@ -528,6 +497,9 @@ public sealed partial class ServerWoundSystem : WoundSystem
                 // Prevent anomalous behaviour
                 Hands.TryDrop(bodyUid, woundableEntity);
             }
+
+            if (Containers.TryGetContainingContainer(parentWoundableEntity, woundableEntity, out var container))
+                Body.DetachPart(parentWoundableEntity, container.ID, woundableEntity);
 
             DropWoundableOrgans(woundableEntity, woundableComp);
             DestroyWoundableChildren(woundableEntity, woundableComp);
@@ -728,11 +700,11 @@ public sealed partial class ServerWoundSystem : WoundSystem
         WoundableComponent? component = null)
     {
         healed = 0;
-        if (!Resolve(woundable, ref component))
+        if (!WoundableQuery.Resolve(woundable, ref component))
             return;
 
         var woundsToHeal =
-            GetWoundableWounds(woundable, component)
+            GetWoundableWounds((woundable, component))
                 .Where(wound => damageGroup == null || wound.Comp.DamageGroup == damageGroup)
                 .ToList();
 
@@ -742,7 +714,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
             RemoveWound(wound, wound);
         }
 
-        Entity<WoundableComponent?> woundableEntity = (woundable, component);
+        Entity<WoundableComponent> woundableEntity = (woundable, component);
 
         UpdateWoundableIntegrity(woundableEntity);
         CheckWoundableSeverityThresholds(woundableEntity);
@@ -779,14 +751,14 @@ public sealed partial class ServerWoundSystem : WoundSystem
         foreach (var wound in woundsToHeal)
         {
             var heal = ignoreMultipliers
-                ? ApplyHealingRateMultipliers((wound,wound), woundable, -healNumba, component)
+                ? ApplyHealingRateMultipliersNullable((wound, wound), woundable, -healNumba, component)
                 : -healNumba;
 
             actualHeal += -heal;
-            ApplyWoundSeverity(wound.AsNullable(), heal);
+            ApplyWoundSeverity(wound, heal);
         }
 
-        Entity<WoundableComponent?> woundableEntity = (woundable, component);
+        Entity<WoundableComponent> woundableEntity = (woundable, component);
 
         UpdateWoundableIntegrity(woundableEntity);
         CheckWoundableSeverityThresholds(woundableEntity);
@@ -826,11 +798,11 @@ public sealed partial class ServerWoundSystem : WoundSystem
         foreach (var wound in woundsToHeal)
         {
             var heal = ignoreMultipliers
-                ? ApplyHealingRateMultipliers((wound,wound), woundable, -healNumba, component)
+                ? ApplyHealingRateMultipliersNullable((wound, wound), woundable, -healNumba, component)
                 : -healNumba;
 
             actualHeal += -heal;
-            ApplyWoundSeverity(wound.AsNullable(), heal);
+            ApplyWoundSeverity(wound, heal);
         }
 
         healed = actualHeal;
@@ -849,8 +821,8 @@ public sealed partial class ServerWoundSystem : WoundSystem
         WoundableComponent? woundableComponent = null,
         WoundComponent? woundComponent = null)
     {
-        if (!WoundableQuery.Resolve(target, ref woundableComponent, false)
-            || !WoundQuery.Resolve(wound, ref woundComponent, false)
+        if (!WoundableQuery.Resolve(target, ref woundableComponent)
+            || !WoundQuery.Resolve(wound, ref woundComponent)
             || woundableComponent.Wounds == null
             || woundableComponent.Wounds.Contains(wound))
             return false;
@@ -868,7 +840,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
         if (!Containers.Insert(wound, woundableComponent.Wounds))
             return false;
 
-        SetWoundSeverity(wound, woundSeverity);
+        SetWoundSeverity((wound, woundComponent), woundSeverity);
 
         var woundMeta = MetaData(wound);
         var targetMeta = MetaData(target);
@@ -895,7 +867,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
 
         Log.Debug($"Wound: {MetaData(woundEntity).EntityPrototype!.ID}({woundEntity}) removed on {MetaData(wound.HoldingWoundable).EntityPrototype!.ID}({wound.HoldingWoundable})");
 
-        Entity<WoundableComponent?> woundableEnt = (wound.HoldingWoundable, woundable);
+        Entity<WoundableComponent> woundableEnt = (wound.HoldingWoundable, woundable);
 
         UpdateWoundableIntegrity(woundableEnt);
         CheckWoundableSeverityThresholds(woundableEnt);
@@ -936,7 +908,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
         if (!Body.TryGetWoundableBodyPartInfo(severed, out _, out var severedPartType, out var severedSymmetry))
             return;
 
-        foreach (var woundEnt in GetWoundableWounds(parent, parentWoundableComp))
+        foreach (var woundEnt in GetWoundableWounds((parent, parentWoundableComp)))
         {
             if (woundEnt.Comp.DamageType != woundComp.DamageType)
                 continue;

--- a/Content.Server/Backmen/Surgery/Wounds/Systems/ServerWoundSystem.cs
+++ b/Content.Server/Backmen/Surgery/Wounds/Systems/ServerWoundSystem.cs
@@ -78,7 +78,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
 
             Entity<WoundableComponent> owner = (ent, woundable);
             var bleedWounds =
-                GetWoundableWoundsWithComp<BleedInflicterComponent>(owner).ToArray();
+                GetWoundableWoundsWithComp<BleedInflicterComponent>(owner.AsNullable()).ToArray();
             var bleedingAmount = bleedWounds.Aggregate(FixedPoint2.Zero,
                     (current, wound) => current + wound.Comp2.BleedingAmount);
 
@@ -95,7 +95,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
                 continue;
 
             var woundsToHeal =
-                GetWoundableWounds(owner)
+                GetWoundableWounds(owner.AsNullable())
                     .Where(wound => CanHealWound(wound, wound))
                     .Where(wound => wound.Comp.DamagedLastTime + wound.Comp.CanHealAfter < Timing.CurTime)
                     .ToArray();
@@ -106,7 +106,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
             var healAmount = -woundable.HealAbility / woundsToHeal.Length;
             foreach (var x in woundsToHeal)
             {
-                ApplyWoundSeverity(x,
+                ApplyWoundSeverity(x.AsNullable(),
                     ApplyHealingRateMultipliersNullable((x, x), owner, healAmount, owner));
             }
         }
@@ -216,10 +216,10 @@ public sealed partial class ServerWoundSystem : WoundSystem
             if (proto.ID != wound.Comp.DamageType)
                 continue;
 
-            if (!RollForWoundMerging(wound, severity))
+            if (!RollForWoundMerging(wound.AsNullable(), severity))
                 continue;
 
-            ApplyWoundSeverity(wound, severity);
+            ApplyWoundSeverity(wound.AsNullable(), severity);
             woundContinued = wound;
 
             return true;
@@ -256,7 +256,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
     }
 
     [PublicAPI]
-    public override void ApplyWoundSeverityNullable(
+    public override void ApplyWoundSeverity(
         Entity<WoundComponent?> woundEnt,
         FixedPoint2 severity)
     {
@@ -286,7 +286,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
     }
 
     [PublicAPI]
-    public override void SetWoundSeverityNullable(
+    public override void SetWoundSeverity(
         Entity<WoundComponent?> woundEnt,
         FixedPoint2 severity)
     {
@@ -320,7 +320,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
     #region Severity Multipliers
 
     [PublicAPI]
-    public override bool TryAddWoundableSeverityMultiplierNullable(
+    public override bool TryAddWoundableSeverityMultiplier(
         Entity<WoundableComponent?> woundable,
         EntityUid owner,
         FixedPoint2 change,
@@ -333,7 +333,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
         if (!comp.SeverityMultipliers.TryAdd(owner, new WoundableSeverityMultiplier(change, identifier)))
             return false;
 
-        foreach (var wound in GetWoundableWoundsNullable(woundable))
+        foreach (var wound in GetWoundableWounds(woundable))
         {
             CheckSeverityThresholds(wound);
         }
@@ -439,16 +439,18 @@ public sealed partial class ServerWoundSystem : WoundSystem
 
     #region Detaching Woundables
 
-    // TODO: REWORK THIS
     [PublicAPI]
     public override void DestroyWoundable(
-        EntityUid parentWoundableEntity,
-        EntityUid woundableEntity,
-        WoundableComponent? woundableComp = null,
-        WoundableComponent? parentWoundableComp = null)
+        Entity<WoundableComponent?> parentWoundableEntity,
+        Entity<WoundableComponent?> woundableEntity)
     {
+        var (woundableUid, woundableComp) = woundableEntity;
+        var (parentWoundableUid, parentWoundableComp) = parentWoundableEntity;
         if (!WoundableQuery.Resolve(woundableEntity, ref woundableComp)
-            || !TryResolveDestroyParent(parentWoundableEntity, ref parentWoundableComp, out parentWoundableEntity))
+            || !WoundableQuery.Resolve(parentWoundableEntity, ref parentWoundableComp))
+            return;
+
+        if (!Body.TryGetWoundableBodyPartInfo(woundableUid, out var bodyUid, out var partType, out _))
             return;
 
         // if wounds amount somehow changes, it triggers an enumeration error. owch
@@ -459,26 +461,22 @@ public sealed partial class ServerWoundSystem : WoundSystem
             nameof(WoundableComponent.WoundableSeverity));
 
         if (TryComp<TargetingComponent>(bodyUid, out var targeting))
-        {
             RefreshBodyTargetingStatus(bodyUid, targeting);
-        }
 
         Audio.PlayPvs(woundableComp.WoundableDestroyedSound, bodyUid);
 
-        if (IsWoundableRoot(woundableEntity, woundableComp))
+        if (IsWoundableRoot(woundableEntity))
         {
             DropWoundableOrgans(woundableEntity, woundableComp);
-            DestroyWoundableChildren(woundableEntity, woundableComp);
+            DestroyWoundableChildren((woundableUid, woundableComp));
 
             if (TryComp<OrganComponent>(woundableEntity, out var rootOrgan))
                 TryViolentlyRemoveOrgan(woundableEntity, rootOrgan);
 
-            TryDeleteWoundableAfterDetach(woundableEntity);
+            Body.DetachPartFromRoot();
 
-            // start-backmen: surgery-gib-threshold
-            if (EntityManager.System<BkmSurgeryDestructibleSystem>().ShouldFullBodyGib(bodyUid))
-                Body.GibBody(bodyUid); // More blood for the Blood Gods!
-            // end-backmen: surgery-gib-threshold
+            // TODO: Check for if it's a separated body or a full body
+            Body.GibBody(bodyUid);
         }
         else
         {
@@ -502,9 +500,9 @@ public sealed partial class ServerWoundSystem : WoundSystem
                 Body.DetachPart(parentWoundableEntity, container.ID, woundableEntity);
 
             DropWoundableOrgans(woundableEntity, woundableComp);
-            DestroyWoundableChildren(woundableEntity, woundableComp);
+            DestroyWoundableChildren((woundableEntity, woundableComp));
 
-            foreach (var wound in GetWoundableWounds(woundableEntity, woundableComp))
+            foreach (var wound in GetWoundableWounds(woundableEntity))
             {
                 TransferWoundDamage(parentWoundableEntity, woundableEntity, wound, parentWoundableComp, wound);
             }
@@ -524,7 +522,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
                 return;
 
             foreach (var wound in
-                     GetWoundableWoundsWithComp<BleedInflicterComponent>(parentWoundableEntity, parentWoundableComp))
+                     GetWoundableWoundsWithComp<BleedInflicterComponent>(parentWoundableEntity))
             {
                 // Bleeding :3
                 wound.Comp2.ScalingLimit += 4;
@@ -541,14 +539,6 @@ public sealed partial class ServerWoundSystem : WoundSystem
     {
         return Containers.TryGetContainingContainer(entity, out var container)
             && HasComp<BkmDetachedBodyComponent>(container.Owner);
-    }
-
-    private void TryDeleteWoundableAfterDetach(EntityUid woundableEntity)
-    {
-        if (IsInDetachedBodyBundle(woundableEntity))
-            return;
-
-        QueueDel(woundableEntity);
     }
 
     private void TryViolentlyRemoveOrgan(EntityUid woundableEntity, OrganComponent organ)
@@ -585,13 +575,13 @@ public sealed partial class ServerWoundSystem : WoundSystem
 
     [PublicAPI]
     public override void AmputateWoundable(
-        EntityUid parentWoundableEntity,
-        EntityUid woundableEntity,
-        WoundableComponent? woundableComp = null,
-        WoundableComponent? parentWoundableComp = null)
+        Entity<WoundableComponent?> parentWoundableEntity,
+        Entity<WoundableComponent?> woundableEntity)
     {
-        if (!WoundableQuery.Resolve(woundableEntity, ref woundableComp)
-            || !WoundableQuery.Resolve(parentWoundableEntity, ref parentWoundableComp))
+        var (woundableUid, woundableComp) = woundableEntity;
+        var (parentWoundableUid, parentWoundableComp) = parentWoundableEntity;
+        if (!WoundableQuery.Resolve(woundableUid, ref woundableComp)
+            || !WoundableQuery.Resolve(parentWoundableUid, ref parentWoundableComp))
             return;
 
         if (!Body.TryGetWoundableBodyPartInfo(parentWoundableEntity, out var bodyUid, out _, out _))
@@ -599,7 +589,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
 
         Audio.PlayPvs(woundableComp.WoundableDelimbedSound, bodyUid);
 
-        foreach (var wound in GetWoundableWounds(woundableEntity, woundableComp))
+        foreach (var wound in GetWoundableWounds(woundableEntity))
         {
             TransferWoundDamage(parentWoundableEntity, woundableEntity, wound);
         }
@@ -609,7 +599,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
             return;
 
         foreach (var wound in
-                 GetWoundableWoundsWithComp<BleedInflicterComponent>(parentWoundableEntity, parentWoundableComp))
+                 GetWoundableWoundsWithComp<BleedInflicterComponent>(parentWoundableEntity))
         {
             wound.Comp2.ScalingLimit += 4;
         }
@@ -755,7 +745,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
                 : -healNumba;
 
             actualHeal += -heal;
-            ApplyWoundSeverity(wound, heal);
+            ApplyWoundSeverity(wound.AsNullable(), heal);
         }
 
         Entity<WoundableComponent> woundableEntity = (woundable, component);
@@ -802,7 +792,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
                 : -healNumba;
 
             actualHeal += -heal;
-            ApplyWoundSeverity(wound, heal);
+            ApplyWoundSeverity(wound.AsNullable(), heal);
         }
 
         healed = actualHeal;

--- a/Content.Server/Backmen/Surgery/Wounds/Systems/ServerWoundSystem.cs
+++ b/Content.Server/Backmen/Surgery/Wounds/Systems/ServerWoundSystem.cs
@@ -352,6 +352,9 @@ public sealed partial class ServerWoundSystem : WoundSystem
         if (!WoundableQuery.Resolve(uid, ref component))
             return false;
 
+        if (component.Wounds == null)
+            return false;
+
         foreach (var multiplier in
                  component.SeverityMultipliers.Where(multiplier => multiplier.Value.Identifier == identifier))
         {
@@ -382,6 +385,9 @@ public sealed partial class ServerWoundSystem : WoundSystem
         WoundableComponent? component = null)
     {
         if (!WoundableQuery.Resolve(uid, ref component))
+            return false;
+
+        if (component.Wounds == null)
             return false;
 
         foreach (var multiplier in
@@ -754,6 +760,9 @@ public sealed partial class ServerWoundSystem : WoundSystem
         if (!Resolve(woundable, ref component))
             return false;
 
+        if (component.Wounds == null)
+            return false;
+
         var woundsToHeal =
             (from wound in component.Wounds.ContainedEntities
                 let woundComp = Comp<WoundComponent>(wound)
@@ -798,6 +807,9 @@ public sealed partial class ServerWoundSystem : WoundSystem
         if (!Resolve(woundable, ref component))
             return false;
 
+        if (component.Wounds == null)
+            return false;
+
         var woundsToHeal =
             (from wound in component.Wounds.ContainedEntities
                 let woundComp = Comp<WoundComponent>(wound)
@@ -839,6 +851,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
     {
         if (!WoundableQuery.Resolve(target, ref woundableComponent, false)
             || !WoundQuery.Resolve(wound, ref woundComponent, false)
+            || woundableComponent.Wounds == null
             || woundableComponent.Wounds.Contains(wound))
             return false;
 
@@ -876,6 +889,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
     {
         if (!WoundQuery.Resolve(woundEntity, ref wound, false)
             || !WoundableQuery.TryComp(wound.HoldingWoundable, out var woundable)
+            || woundable.Wounds == null
             || !woundable.Wounds.Contains(woundEntity))
             return false;
 

--- a/Content.Server/Backmen/Surgery/Wounds/Systems/ServerWoundSystem.cs
+++ b/Content.Server/Backmen/Surgery/Wounds/Systems/ServerWoundSystem.cs
@@ -106,9 +106,8 @@ public sealed partial class ServerWoundSystem : WoundSystem
             Entity<WoundableComponent> owner = (ent, woundable);
             foreach (var x in woundsToHeal)
             {
-                ApplyWoundSeverity(x,
-                    ApplyHealingRateMultipliers((x,x), owner, healAmount, owner),
-                    x);
+                ApplyWoundSeverity(x.AsNullable(),
+                    ApplyHealingRateMultipliers((x,x), owner, healAmount, owner));
             }
         }
     }
@@ -220,7 +219,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
             if (!RollForWoundMerging(wound.AsNullable(), severity))
                 continue;
 
-            ApplyWoundSeverity(wound, severity, wound);
+            ApplyWoundSeverity(wound.AsNullable(), severity);
             woundContinued = wound;
 
             return true;
@@ -258,10 +257,10 @@ public sealed partial class ServerWoundSystem : WoundSystem
 
     [PublicAPI]
     public override void ApplyWoundSeverity(
-        EntityUid uid,
-        FixedPoint2 severity,
-        WoundComponent? wound = null)
+        Entity<WoundComponent?> woundEnt,
+        FixedPoint2 severity)
     {
+        var (uid, wound) = woundEnt;
         if (!WoundQuery.Resolve(uid, ref wound))
             return;
 
@@ -277,26 +276,27 @@ public sealed partial class ServerWoundSystem : WoundSystem
         if (wound.WoundSeverityPoint == old)
             return;
 
-        Entity<WoundableComponent> holdingWoundable = (wound.HoldingWoundable, holdingComp);
+        Entity<WoundableComponent?> holdingWoundable = (wound.HoldingWoundable, holdingComp);
 
-        RaiseWoundEvents(uid, holdingWoundable, wound, old, holdingWoundable);
-        CheckSeverityThresholds(uid, wound);
+        RaiseWoundEvents(woundEnt, holdingWoundable, old);
+        CheckSeverityThresholds(woundEnt);
 
-        UpdateWoundableIntegrity(holdingWoundable, holdingWoundable);
-        CheckWoundableSeverityThresholds(holdingWoundable, holdingWoundable);
+        UpdateWoundableIntegrity(holdingWoundable);
+        CheckWoundableSeverityThresholds(holdingWoundable);
     }
 
     [PublicAPI]
     public override void SetWoundSeverity(
-        EntityUid uid,
-        FixedPoint2 severity,
-        WoundComponent? wound = null)
+        Entity<WoundComponent?> woundEnt,
+        FixedPoint2 severity)
     {
+        var (uid, wound) = woundEnt;
         if (!WoundQuery.Resolve(uid, ref wound))
             return;
 
         // No reason to update the wound if the woundable it is stored in is about to be deleted.
-        if (TerminatingOrDeleted(wound.HoldingWoundable) || !WoundableQuery.TryComp(wound.HoldingWoundable, out var holdingComp))
+        if (TerminatingOrDeleted(wound.HoldingWoundable)
+            || !WoundableQuery.TryComp(wound.HoldingWoundable, out var holdingComp))
             return;
 
         var old = wound.WoundSeverityPoint;
@@ -306,13 +306,13 @@ public sealed partial class ServerWoundSystem : WoundSystem
         if (wound.WoundSeverityPoint == old)
             return;
 
-        Entity<WoundableComponent> holdingWoundable = (wound.HoldingWoundable, holdingComp);
+        Entity<WoundableComponent?> holdingWoundable = (wound.HoldingWoundable, holdingComp);
 
-        RaiseWoundEvents(uid, holdingWoundable, wound, old, holdingWoundable);
-        CheckSeverityThresholds(uid, wound);
+        RaiseWoundEvents(woundEnt, holdingWoundable, old);
+        CheckSeverityThresholds(woundEnt);
 
-        UpdateWoundableIntegrity(holdingWoundable, holdingWoundable);
-        CheckWoundableSeverityThresholds(holdingWoundable, holdingWoundable);
+        UpdateWoundableIntegrity(holdingWoundable);
+        CheckWoundableSeverityThresholds(holdingWoundable);
     }
 
     #endregion
@@ -321,25 +321,24 @@ public sealed partial class ServerWoundSystem : WoundSystem
 
     [PublicAPI]
     public override bool TryAddWoundableSeverityMultiplier(
-        EntityUid uid,
+        Entity<WoundableComponent?> woundable,
         EntityUid owner,
         FixedPoint2 change,
-        string identifier,
-        WoundableComponent? component = null)
+        string identifier)
     {
-        if (!WoundableQuery.Resolve(uid, ref component) || component.Wounds == null)
+        if (!WoundableQuery.Resolve(woundable, ref woundable.Comp))
             return false;
 
-        if (!component.SeverityMultipliers.TryAdd(owner, new WoundableSeverityMultiplier(change, identifier)))
+        if (!woundable.Comp.SeverityMultipliers.TryAdd(owner, new WoundableSeverityMultiplier(change, identifier)))
             return false;
 
-        foreach (var wound in GetWoundableWounds(uid, component))
+        foreach (var wound in GetWoundableWounds(woundable))
         {
-            CheckSeverityThresholds(wound, wound);
+            CheckSeverityThresholds(wound.AsNullable());
         }
 
-        UpdateWoundableIntegrity(uid, component);
-        CheckWoundableSeverityThresholds(uid, component);
+        UpdateWoundableIntegrity(woundable);
+        CheckWoundableSeverityThresholds(woundable);
 
         return true;
     }
@@ -350,7 +349,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
         string identifier,
         WoundableComponent? component = null)
     {
-        if (!WoundableQuery.Resolve(uid, ref component) || component.Wounds == null)
+        if (!WoundableQuery.Resolve(uid, ref component))
             return false;
 
         foreach (var multiplier in
@@ -364,8 +363,10 @@ public sealed partial class ServerWoundSystem : WoundSystem
                 CheckSeverityThresholds(wound);
             }
 
-            UpdateWoundableIntegrity(uid, component);
-            CheckWoundableSeverityThresholds(uid, component);
+            Entity<WoundableComponent?> woundable = (uid, component);
+
+            UpdateWoundableIntegrity(woundable);
+            CheckWoundableSeverityThresholds(woundable);
 
             return true;
         }
@@ -380,7 +381,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
         FixedPoint2 change,
         WoundableComponent? component = null)
     {
-        if (!WoundableQuery.Resolve(uid, ref component) || component.Wounds == null)
+        if (!WoundableQuery.Resolve(uid, ref component))
             return false;
 
         foreach (var multiplier in
@@ -396,8 +397,10 @@ public sealed partial class ServerWoundSystem : WoundSystem
                 CheckSeverityThresholds(wound);
             }
 
-            UpdateWoundableIntegrity(uid, component);
-            CheckWoundableSeverityThresholds(uid, component);
+            Entity<WoundableComponent?> woundable = (uid, component);
+
+            UpdateWoundableIntegrity(woundable);
+            CheckWoundableSeverityThresholds(woundable);
 
             return true;
         }
@@ -440,7 +443,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
             || !TryResolveDestroyParent(parentWoundableEntity, ref parentWoundableComp, out parentWoundableEntity))
             return;
 
-        if (!Body.TryGetWoundableBodyPartInfo(woundableEntity, out var bodyUid, out var partType, out var symmetry))
+        if (!Body.TryGetWoundableBodyPartInfo(woundableEntity, out var bodyUid, out var partType, out _))
         {
             if (HasComp<BrainComponent>(woundableEntity))
             {
@@ -733,8 +736,10 @@ public sealed partial class ServerWoundSystem : WoundSystem
             RemoveWound(wound, wound);
         }
 
-        UpdateWoundableIntegrity(woundable, component);
-        CheckWoundableSeverityThresholds(woundable, component);
+        Entity<WoundableComponent?> woundableEntity = (woundable, component);
+
+        UpdateWoundableIntegrity(woundableEntity);
+        CheckWoundableSeverityThresholds(woundableEntity);
     }
 
     [PublicAPI]
@@ -746,7 +751,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
         bool ignoreMultipliers = false)
     {
         healed = 0;
-        if (!Resolve(woundable, ref component) || component.Wounds == null)
+        if (!Resolve(woundable, ref component))
             return false;
 
         var woundsToHeal =
@@ -769,11 +774,13 @@ public sealed partial class ServerWoundSystem : WoundSystem
                 : -healNumba;
 
             actualHeal += -heal;
-            ApplyWoundSeverity(wound, heal, wound);
+            ApplyWoundSeverity(wound.AsNullable(), heal);
         }
 
-        UpdateWoundableIntegrity(woundable, component);
-        CheckWoundableSeverityThresholds(woundable, component);
+        Entity<WoundableComponent?> woundableEntity = (woundable, component);
+
+        UpdateWoundableIntegrity(woundableEntity);
+        CheckWoundableSeverityThresholds(woundableEntity);
 
         healed = actualHeal;
         return actualHeal > 0;
@@ -788,7 +795,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
         bool ignoreMultipliers = false)
     {
         healed = 0;
-        if (!Resolve(woundable, ref component) || component.Wounds == null)
+        if (!Resolve(woundable, ref component))
             return false;
 
         var woundsToHeal =
@@ -811,7 +818,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
                 : -healNumba;
 
             actualHeal += -heal;
-            ApplyWoundSeverity(wound, heal, wound);
+            ApplyWoundSeverity(wound.AsNullable(), heal);
         }
 
         healed = actualHeal;
@@ -832,7 +839,6 @@ public sealed partial class ServerWoundSystem : WoundSystem
     {
         if (!WoundableQuery.Resolve(target, ref woundableComponent, false)
             || !WoundQuery.Resolve(wound, ref woundComponent, false)
-            || woundableComponent.Wounds == null
             || woundableComponent.Wounds.Contains(wound))
             return false;
 
@@ -849,7 +855,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
         if (!Containers.Insert(wound, woundableComponent.Wounds))
             return false;
 
-        SetWoundSeverity(wound, woundSeverity, woundComponent);
+        SetWoundSeverity(wound, woundSeverity);
 
         var woundMeta = MetaData(wound);
         var targetMeta = MetaData(target);
@@ -870,15 +876,15 @@ public sealed partial class ServerWoundSystem : WoundSystem
     {
         if (!WoundQuery.Resolve(woundEntity, ref wound, false)
             || !WoundableQuery.TryComp(wound.HoldingWoundable, out var woundable)
-            || woundable.Wounds == null
             || !woundable.Wounds.Contains(woundEntity))
             return false;
 
         Log.Debug($"Wound: {MetaData(woundEntity).EntityPrototype!.ID}({woundEntity}) removed on {MetaData(wound.HoldingWoundable).EntityPrototype!.ID}({wound.HoldingWoundable})");
 
-        var woundableEnt = wound.HoldingWoundable;
-        UpdateWoundableIntegrity(wound.HoldingWoundable, woundable);
-        CheckWoundableSeverityThresholds(wound.HoldingWoundable, woundable);
+        Entity<WoundableComponent?> woundableEnt = (wound.HoldingWoundable, woundable);
+
+        UpdateWoundableIntegrity(woundableEnt);
+        CheckWoundableSeverityThresholds(woundableEnt);
 
         var woundChangedEvent = new WoundChangedEvent(
             wound,
@@ -888,7 +894,7 @@ public sealed partial class ServerWoundSystem : WoundSystem
         var damageSpec = new DamageSpecifier();
         damageSpec.DamageDict.Add(wound.DamageType, -wound.WoundSeverityPoint);
 
-        GetWoundsChanged(woundableEnt, woundableEnt, damageSpec, false, woundable);
+        GetWoundsChanged(woundableEnt, woundableEnt, damageSpec, false);
 
         Containers.Remove(woundEntity, woundable.Wounds!, false, true);
         _pain.RefreshWoundablePain(woundableEnt, woundable); // backmen: phantom-pain-fix

--- a/Content.Server/Backmen/Surgery/Wounds/Systems/ServerWoundSystem.cs
+++ b/Content.Server/Backmen/Surgery/Wounds/Systems/ServerWoundSystem.cs
@@ -217,6 +217,9 @@ public sealed partial class ServerWoundSystem : WoundSystem
             if (proto.ID != wound.Comp.DamageType)
                 continue;
 
+            if (!RollForWoundMerging(wound.AsNullable(), severity))
+                continue;
+
             ApplyWoundSeverity(wound, severity, wound);
             woundContinued = wound;
 
@@ -810,9 +813,6 @@ public sealed partial class ServerWoundSystem : WoundSystem
             actualHeal += -heal;
             ApplyWoundSeverity(wound, heal, wound);
         }
-
-        UpdateWoundableIntegrity(woundable, component);
-        CheckWoundableSeverityThresholds(woundable, component);
 
         healed = actualHeal;
         return actualHeal > 0;

--- a/Content.Server/Backmen/Tourniquet/TourniquetSystem.cs
+++ b/Content.Server/Backmen/Tourniquet/TourniquetSystem.cs
@@ -18,7 +18,6 @@ using Content.Shared.Verbs;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
-using Robust.Shared.GameObjects;
 
 namespace Content.Server.Backmen.Tourniquet;
 
@@ -140,7 +139,7 @@ public sealed partial class TourniquetSystem : EntitySystem
         }
 
         // start-backmen: medical-targeting
-        if (!TryGetEntity(args.TargetWoundable, out var targetPart) || targetPart == null)
+        if (!TryGetEntity(args.TargetWoundable, out var targetPart))
         {
             _popup.PopupEntity(Loc.GetString("does-not-exist-rebell"), ent, args.User, PopupType.MediumCaution);
             args.Handled = true;

--- a/Content.Shared/Backmen/Body/Components/ComplexBodyComponent.cs
+++ b/Content.Shared/Backmen/Body/Components/ComplexBodyComponent.cs
@@ -1,0 +1,32 @@
+using Content.Shared.Backmen.Body.Systems;
+using Robust.Shared.Audio;
+using Robust.Shared.Containers;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Backmen.Body.Components;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(BkmBodySharedSystem))]
+public sealed partial class ComplexBodyComponent : Component
+{
+    /// <summary>
+    /// Relevant template to spawn for this body.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public ProtoId<BodyPrototype>? Prototype;
+
+    /// <summary>
+    /// Container that holds the root body part.
+    /// </summary>
+    /// <remarks>
+    /// Typically is the torso.
+    /// </remarks>
+    [ViewVariables] public ContainerSlot RootContainer = default!;
+
+    [ViewVariables]
+    public string RootPartSlot => RootContainer.ID;
+
+    [DataField, AutoNetworkedField]
+    public SoundSpecifier GibSound = new SoundCollectionSpecifier("gib");
+}

--- a/Content.Shared/Backmen/Body/OrganRelations/BkmDetachedBodySystem.cs
+++ b/Content.Shared/Backmen/Body/OrganRelations/BkmDetachedBodySystem.cs
@@ -80,7 +80,7 @@ public sealed partial class BkmDetachedBodySystem : EntitySystem
 
         if (TryComp<WoundableComponent>(rootOrgan, out var woundable))
         {
-            actuallyInduced = _wounds.GetWoundsChanged(rootOrgan, args.Origin, args.Damage, component: woundable);
+            actuallyInduced = _wounds.GetWoundsChanged((rootOrgan, woundable), args.Origin, args.Damage);
             container = woundable.DamageContainer;
         }
         else

--- a/Content.Shared/Backmen/Body/Systems/BkmBodySharedSystem.Parts.cs
+++ b/Content.Shared/Backmen/Body/Systems/BkmBodySharedSystem.Parts.cs
@@ -421,39 +421,6 @@ public partial class BkmBodySharedSystem
     #region RootPartManagement
 
     /// <summary>
-    /// Returns true if the partId is the root body container for the specified bodyId.
-    /// </summary>
-    public bool IsPartRoot(
-        EntityUid bodyId,
-        EntityUid partId,
-        BodyComponent? body = null,
-        BodyPartComponent? part = null)
-    {
-        return Resolve(partId, ref part)
-            && Resolve(bodyId, ref body)
-            && Containers.TryGetContainingContainer(bodyId, partId, out var container)
-            && container.ID == BodyRootContainerId;
-    }
-
-    /// <summary>
-    /// Returns true if we can attach the partId to the bodyId as the root entity.
-    /// </summary>
-    public bool CanAttachToRoot(
-        EntityUid bodyId,
-        EntityUid partId,
-        BodyComponent? body = null,
-        BodyPartComponent? part = null)
-    {
-        return false;
-    }
-
-    /// <summary>
-    /// Returns the root part of this body if it exists.
-    /// </summary>
-    public (EntityUid Entity, BodyPartComponent BodyPart)? GetRootPartOrNull(EntityUid bodyId, BodyComponent? body = null) =>
-        null;
-
-    /// <summary>
     /// Returns true if the partId can be attached to the parentId in the specified slot.
     /// </summary>
     public bool CanAttachPart(

--- a/Content.Shared/Backmen/Body/Systems/BkmBodySharedSystem.Woundables.cs
+++ b/Content.Shared/Backmen/Body/Systems/BkmBodySharedSystem.Woundables.cs
@@ -31,7 +31,7 @@ public partial class BkmBodySharedSystem
     /// </summary>
     public IEnumerable<EntityUid> GetWoundableTargets(EntityUid bodyId, BodyComponent? body = null)
     {
-        if (!Resolve(bodyId, ref body, logMissing: false) || body!.Organs == null)
+        if (!Resolve(bodyId, ref body, logMissing: false) || body.Organs == null)
             yield break;
 
         foreach (var organUid in body.Organs.ContainedEntities.ToArray())

--- a/Content.Shared/Backmen/Body/Systems/BkmBodySharedSystem.Woundables.cs
+++ b/Content.Shared/Backmen/Body/Systems/BkmBodySharedSystem.Woundables.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Content.Shared.Backmen.Arachne;
+using Content.Shared.Backmen.Surgery.Wounds.Components;
 using Content.Shared.Backmen.Targeting;
 using Content.Shared.Body;
 using Content.Shared.Body.Part;
@@ -29,7 +30,7 @@ public partial class BkmBodySharedSystem
     /// <summary>
     /// Returns woundable surgery targets: nubody external organs.
     /// </summary>
-    public IEnumerable<EntityUid> GetWoundableTargets(EntityUid bodyId, BodyComponent? body = null)
+    public IEnumerable<Entity<WoundableComponent>> GetWoundableTargets(EntityUid bodyId, BodyComponent? body = null)
     {
         if (!Resolve(bodyId, ref body, logMissing: false) || body.Organs == null)
             yield break;
@@ -42,8 +43,11 @@ public partial class BkmBodySharedSystem
             if (!TryComp<OrganComponent>(organUid, out var organ) || organ.Category is not { } category)
                 continue;
 
+            if (!TryComp<WoundableComponent>(organUid, out var woundableComp))
+                continue;
+
             if (SurgeryBodyPartMapping.IsExternalCategory(category))
-                yield return organUid;
+                yield return (organUid, woundableComp);
         }
     }
 

--- a/Content.Shared/Backmen/CCVar/CCVars.ReBELL.cs
+++ b/Content.Shared/Backmen/CCVar/CCVars.ReBELL.cs
@@ -29,16 +29,18 @@ public sealed partial class CCVars
         CVarDef.Create("wounding.wound_scar_chance", 0.10f, CVar.SERVERONLY);
 
     /// <summary>
-    /// What part of wounds will be transferred from a destroyed woundable to its parent?
+    /// How much of the wound's severity will be transferred?
     /// </summary>
     public static readonly CVarDef<float> WoundTransferPart =
         CVarDef.Create("wounding.wound_severity_transfer", 0.10f, CVar.SERVER | CVar.REPLICATED);
 
     /// <summary>
-    /// for every n units of distance, (tiles), chance for dodging is equal to n*x percents, look for it down here
+    /// Per how much damage, the prototype value of "wound chance" is counted
+    /// For example, a wound with merge chance of 0.1, with a merge ratio of 10, and severity of 10
+    /// Would have a merge chance of 0.1, cuz, (severity / merge ratio) * merge chance
     /// </summary>
-    public static readonly CVarDef<float> DodgeDistanceChance =
-        CVarDef.Create("targeting.dodge_chance_distance", 6f, CVar.SERVER | CVar.REPLICATED);
+    public static readonly CVarDef<float> WoundMergeRatio =
+        CVarDef.Create("wounding.wound_merge_ratio", 10f, CVar.SERVER | CVar.REPLICATED);
 
     /// <summary>
     /// the said x amount of percents
@@ -51,7 +53,7 @@ public sealed partial class CCVars
      */
 
     /// <summary>
-    /// Should Pain System work at all?
+    /// Should the Pain System work at all?
     /// </summary>
     public static readonly CVarDef<bool> PainEnabled =
         CVarDef.Create("pain.enabled", true, CVar.SERVER | CVar.REPLICATED);

--- a/Content.Shared/Backmen/Damage/DamageableSystem.Backmen.cs
+++ b/Content.Shared/Backmen/Damage/DamageableSystem.Backmen.cs
@@ -108,7 +108,7 @@ public sealed partial class DamageableSystem
 
             foreach (var wound in _wounds.GetWoundableWounds(part, woundable))
             {
-                _wounds.SetWoundSeverity(wound, newValue, wound);
+                _wounds.SetWoundSeverity(wound.AsNullable(), newValue);
             }
         }
     }

--- a/Content.Shared/Backmen/Surgery/Wounds/Components/WoundComponent.cs
+++ b/Content.Shared/Backmen/Surgery/Wounds/Components/WoundComponent.cs
@@ -58,6 +58,7 @@ public sealed partial class WoundComponent : Component
     [ViewVariables(VVAccess.ReadWrite), DataField]
     public TimeSpan CanHealAfter = TimeSpan.FromSeconds(15f);
 
+    /// TODO: This should be obliterated
     /// <summary>
     /// Damage group of this wound.
     /// </summary>

--- a/Content.Shared/Backmen/Surgery/Wounds/Components/WoundComponent.cs
+++ b/Content.Shared/Backmen/Surgery/Wounds/Components/WoundComponent.cs
@@ -10,7 +10,7 @@ namespace Content.Shared.Backmen.Surgery.Wounds.Components;
 public sealed partial class WoundComponent : Component
 {
     /// <summary>
-    /// 'Parent' of wound. Basically the entity to which the wound was applied.
+    /// The 'Parent' of the wound. Basically the entity to which the wound was applied.
     /// </summary>
     [AutoNetworkedField, ViewVariables(VVAccess.ReadOnly)]
     public EntityUid HoldingWoundable;
@@ -21,7 +21,7 @@ public sealed partial class WoundComponent : Component
     public FixedPoint2 WoundIntegrityDamage => WoundSeverityPoint * WoundableIntegrityMultiplier;
 
     /// <summary>
-    /// Actually, severity of the wound. The more the worse.
+    /// The severity of the wound. The more the worse.
     /// Directly depends on <see cref="WoundSeverity"/>
     /// </summary>
     [AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
@@ -32,6 +32,12 @@ public sealed partial class WoundComponent : Component
     /// </summary>
     [AutoNetworkedField, ViewVariables(VVAccess.ReadOnly), DataField("integrityMultiplier")]
     public FixedPoint2 WoundableIntegrityMultiplier = 1;
+
+    /// <summary>
+    /// With what chance will this wound merge when a new one occurs?
+    /// </summary>
+    [AutoNetworkedField, ViewVariables(VVAccess.ReadOnly), DataField("mergeChance")]
+    public FixedPoint2 MergeChance = 0.1;
 
     /// <summary>
     /// maybe some cool mechanical stuff to treat those wounds later. I genuinely have no idea

--- a/Content.Shared/Backmen/Surgery/Wounds/Components/WoundableComponent.cs
+++ b/Content.Shared/Backmen/Surgery/Wounds/Components/WoundableComponent.cs
@@ -135,7 +135,7 @@ public sealed partial class WoundableComponent : Component
     /// Container potentially holding wounds.
     /// </summary>
     [ViewVariables]
-    public Container Wounds;
+    public Container? Wounds;
 
     //[ViewVariables]
     //public Dictionary<ProtoId<DamageTypePrototype>, List<Entity<WoundComponent>>> WoundsByDamageType = new();

--- a/Content.Shared/Backmen/Surgery/Wounds/Components/WoundableComponent.cs
+++ b/Content.Shared/Backmen/Surgery/Wounds/Components/WoundableComponent.cs
@@ -126,7 +126,7 @@ public sealed partial class WoundableComponent : Component
     public WoundableSeverity WoundableSeverity;
 
     /// <summary>
-    /// How much time in seconds had this woundable accumulated from the last healing tick.
+    /// How much time in seconds had this woundable accumulated from the last healing tick?
     /// </summary>
     [AutoNetworkedField, ViewVariables]
     public float HealingRateAccumulated;
@@ -135,10 +135,13 @@ public sealed partial class WoundableComponent : Component
     /// Container potentially holding wounds.
     /// </summary>
     [ViewVariables]
-    public Container? Wounds;
+    public Container Wounds;
+
+    [ViewVariables]
+    public Dictionary<ProtoId<DamageTypePrototype>, List<Entity<WoundComponent>>> WoundsByDamageType = new();
 
     /// <summary>
-    /// Container holding this woundables bone.
+    /// Container holding this woundable's bone.
     /// </summary>
     [ViewVariables]
     public Container Bone;

--- a/Content.Shared/Backmen/Surgery/Wounds/Components/WoundableComponent.cs
+++ b/Content.Shared/Backmen/Surgery/Wounds/Components/WoundableComponent.cs
@@ -137,8 +137,8 @@ public sealed partial class WoundableComponent : Component
     [ViewVariables]
     public Container Wounds;
 
-    [ViewVariables]
-    public Dictionary<ProtoId<DamageTypePrototype>, List<Entity<WoundComponent>>> WoundsByDamageType = new();
+    //[ViewVariables]
+    //public Dictionary<ProtoId<DamageTypePrototype>, List<Entity<WoundComponent>>> WoundsByDamageType = new();
 
     /// <summary>
     /// Container holding this woundable's bone.

--- a/Content.Shared/Backmen/Surgery/Wounds/Systems/WoundSystem.Healing.cs
+++ b/Content.Shared/Backmen/Surgery/Wounds/Systems/WoundSystem.Healing.cs
@@ -132,7 +132,7 @@ public partial class WoundSystem
     }
 
     [PublicAPI]
-    public FixedPoint2 ApplyHealingRateMultipliers(Entity<WoundComponent?> wound, EntityUid woundable, FixedPoint2 severity, WoundableComponent? component = null)
+    public FixedPoint2 ApplyHealingRateMultipliersNullable(Entity<WoundComponent?> wound, EntityUid woundable, FixedPoint2 severity, WoundableComponent? component = null)
     {
         if (!WoundableQuery.Resolve(woundable, ref component, false))
             return severity;
@@ -149,6 +149,12 @@ public partial class WoundSystem
         var toMultiply =
             component.HealingMultipliers.Sum(multiplier => (float) multiplier.Value.Change) / component.HealingMultipliers.Count;
         return severity * toMultiply * woundHealingMultiplier;
+    }
+
+    [PublicAPI]
+    public FixedPoint2 ApplyHealingRateMultipliers(Entity<WoundComponent> wound, EntityUid woundable, FixedPoint2 severity, WoundableComponent? component = null)
+    {
+        return ApplyHealingRateMultipliersNullable(wound.AsNullable(), woundable, severity, component);
     }
 
     [PublicAPI]

--- a/Content.Shared/Backmen/Surgery/Wounds/Systems/WoundSystem.Wounding.cs
+++ b/Content.Shared/Backmen/Surgery/Wounds/Systems/WoundSystem.Wounding.cs
@@ -1068,6 +1068,7 @@ public partial class WoundSystem
         WoundableComponent? targetWoundable = null)
     {
         if (!WoundableQuery.Resolve(targetEntity, ref targetWoundable, false)
+            || targetWoundable.Wounds == null
             || targetWoundable.Wounds.Count == 0)
             yield break;
 
@@ -1088,6 +1089,7 @@ public partial class WoundSystem
         WoundableComponent? targetWoundable = null) where T: Component, new()
     {
         if (!WoundableQuery.Resolve(targetEntity, ref targetWoundable, false)
+            || targetWoundable.Wounds == null
             || targetWoundable.Wounds.Count == 0)
             yield break;
 
@@ -1115,6 +1117,7 @@ public partial class WoundSystem
         bool healable = false)
     {
         if (!WoundableQuery.Resolve(targetEntity, ref targetWoundable, false)
+            || targetWoundable.Wounds == null
             || targetWoundable.Wounds.Count == 0)
             return FixedPoint2.Zero;
 
@@ -1182,6 +1185,7 @@ public partial class WoundSystem
     {
         var (targetEntity, targetWoundable) = woundable;
         if (!WoundableQuery.Resolve(targetEntity, ref targetWoundable, false)
+            || targetWoundable.Wounds == null
             || targetWoundable.Wounds.Count == 0)
             return FixedPoint2.Zero;
 

--- a/Content.Shared/Backmen/Surgery/Wounds/Systems/WoundSystem.Wounding.cs
+++ b/Content.Shared/Backmen/Surgery/Wounds/Systems/WoundSystem.Wounding.cs
@@ -406,7 +406,8 @@ public partial class WoundSystem
         string id,
         FixedPoint2 severity,
         [NotNullWhen(true)] out Entity<WoundComponent>? continuableWound,
-        WoundableComponent? woundable = null)
+        WoundableComponent? woundable = null,
+        bool forceMerging = false)
     {
         continuableWound = null;
         if (!IsWoundPrototypeValid(id))
@@ -421,7 +422,7 @@ public partial class WoundSystem
             if (proto.ID != wound.Comp.DamageType)
                 continue;
 
-            if (severity > 0 && !RollForWoundMerging(wound.AsNullable(), severity))
+            if (severity > 0 && (!RollForWoundMerging(wound.AsNullable(), severity) || forceMerging))
                 continue;
 
             continuableWound = wound;
@@ -544,7 +545,8 @@ public partial class WoundSystem
                     damagePiece.Key,
                     damagePiece.Value,
                     out var continuedWound,
-                    component))
+                    component,
+                    !performLogic))
             {
                 if (damagePiece.Value <= 0 || !CanAddWound(
                         ent,

--- a/Content.Shared/Backmen/Surgery/Wounds/Systems/WoundSystem.Wounding.cs
+++ b/Content.Shared/Backmen/Surgery/Wounds/Systems/WoundSystem.Wounding.cs
@@ -18,6 +18,7 @@ using Content.Shared.Gibbing.Events;
 using JetBrains.Annotations;
 using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
 
 namespace Content.Shared.Backmen.Surgery.Wounds.Systems;
 
@@ -28,8 +29,7 @@ public partial class WoundSystem
 
     private const string WoundableDestroyalIdentifier = "WoundableDestroyal";
 
-    private float _dodgeDistanceChance;
-    private float _dodgeDistanceChange;
+    private float _woundMergeRatio;
 
     protected EntityQuery<WoundComponent> WoundQuery;
     protected EntityQuery<WoundableComponent> WoundableQuery;
@@ -56,8 +56,7 @@ public partial class WoundSystem
         //SubscribeLocalEvent<WoundableComponent, BeforeDamageChangedEvent>(CheckDodge);
         SubscribeLocalEvent<WoundableComponent, WoundHealAttemptOnWoundableEvent>(HealWoundsOnWoundableAttempt);
 
-        Subs.CVar(Cfg, CCVars.DodgeDistanceChance, val => _dodgeDistanceChance = val, true);
-        Subs.CVar(Cfg, CCVars.DodgeDistanceChange, val => _dodgeDistanceChange = val, true);
+        Subs.CVar(Cfg, CCVars.WoundMergeRatio, val => _woundMergeRatio = val, true);
 
         WoundQuery = GetEntityQuery<WoundComponent>();
         WoundableQuery = GetEntityQuery<WoundableComponent>();
@@ -374,6 +373,21 @@ public partial class WoundSystem
     }
 
     [PublicAPI]
+    public bool RollForWoundMerging(
+        Entity<WoundComponent?> woundProgenitor,
+        FixedPoint2 severity)
+    {
+        if (severity < FixedPoint2.Zero)
+            return false;
+
+        if (!WoundQuery.Resolve(woundProgenitor, ref woundProgenitor.Comp))
+            return false;
+
+        var chance = woundProgenitor.Comp.MergeChance * (severity / _woundMergeRatio);
+        return Random.Prob((float) chance);
+    }
+
+    [PublicAPI]
     public bool CanContinueWound(
         EntityUid uid,
         string id,
@@ -395,6 +409,9 @@ public partial class WoundSystem
         foreach (var wound in GetWoundableWounds(uid, woundable))
         {
             if (proto.ID != wound.Comp.DamageType)
+                continue;
+
+            if (!RollForWoundMerging(wound.AsNullable(), severity))
                 continue;
 
             continuableWound = wound;
@@ -505,52 +522,20 @@ public partial class WoundSystem
         var changedWounds = new Dictionary<Entity<WoundComponent>, FixedPoint2>();
         var totalChange = FixedPoint2.Zero;
 
+        // TODO: Cache a list of wounds of a SPECIFIC damage type and pull it up, to cut down on computation costs
         foreach (var damagePiece in damage.DamageDict)
         {
-            if (TryGetWoundOfDamageType(woundable, damagePiece.Key, out var foundWound, component))
-            {
-                // Healing ignores severity modifiers
-                var severityApplied = damagePiece.Value > 0
-                    ? ApplySeverityModifiers(woundable, damagePiece.Value, component)
-                    : damagePiece.Value;
+            // Healing ignores healing modifiers
+            var severityApplied = damagePiece.Value > 0
+                ? ApplySeverityModifiers(woundable, damagePiece.Value, component)
+                : damagePiece.Value;
 
-                if (severityApplied < 0 && -severityApplied > foundWound.Value.Comp.WoundSeverityPoint)
-                {
-                    actuallyInducedDamage.DamageDict[damagePiece.Key] = -foundWound.Value.Comp.WoundSeverityPoint;
-
-                    removedWounds.Add(foundWound.Value);
-                    changedWounds.Add(foundWound.Value, -foundWound.Value.Comp.WoundSeverityPoint);
-                    totalChange -= foundWound.Value.Comp.WoundSeverityPoint;
-                }
-                else
-                {
-                    if (!CanContinueWound(
-                            woundable,
-                            damagePiece.Key,
-                            damagePiece.Value,
-                            out var continuedWound,
-                            component))
-                    {
-                        actuallyInducedDamage.DamageDict[damagePiece.Key] = 0;
-                        continue;
-                    }
-
-                    var currentSeverity = continuedWound.Value.Comp.WoundSeverityPoint;
-                    var severityDelta = FixedPoint2.Max(FixedPoint2.Zero, currentSeverity + severityApplied)
-                        - currentSeverity;
-
-                    actuallyInducedDamage.DamageDict[damagePiece.Key] = severityDelta;
-                    if (severityDelta > FixedPoint2.Zero)
-                        damageIncreased = true;
-
-                    if (severityDelta == FixedPoint2.Zero)
-                        continue;
-
-                    changedWounds.Add(continuedWound.Value, severityDelta);
-                    totalChange += severityDelta;
-                }
-            }
-            else
+            if (!CanContinueWound(
+                    woundable,
+                    damagePiece.Key,
+                    damagePiece.Value,
+                    out var continuedWound,
+                    component))
             {
                 if (damagePiece.Value <= 0 || !CanAddWound(
                         woundable,
@@ -575,6 +560,22 @@ public partial class WoundSystem
 
                 woundsToAdd.Add(damagePiece.Key, severity);
                 totalChange += severity;
+            }
+            else
+            {
+                var currentSeverity = continuedWound.Value.Comp.WoundSeverityPoint;
+                var severityDelta = FixedPoint2.Max(FixedPoint2.Zero, currentSeverity + severityApplied)
+                                    - currentSeverity;
+
+                actuallyInducedDamage.DamageDict[damagePiece.Key] = severityDelta;
+                if (severityDelta > FixedPoint2.Zero)
+                    damageIncreased = true;
+
+                if (severityDelta == FixedPoint2.Zero)
+                    continue;
+
+                changedWounds.Add(continuedWound.Value, severityDelta);
+                totalChange += severityDelta;
             }
         }
 

--- a/Content.Shared/Backmen/Surgery/Wounds/Systems/WoundSystem.Wounding.cs
+++ b/Content.Shared/Backmen/Surgery/Wounds/Systems/WoundSystem.Wounding.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Content.Shared.Backmen.CCVar;
-using Content.Shared.Backmen.Body.OrganRelations;
 using Content.Shared.Backmen.Surgery.Consciousness.Systems;
 using Content.Shared.Backmen.Surgery.Pain.Components;
 using Content.Shared.Backmen.Surgery.Traumas.Components;
@@ -95,15 +94,16 @@ public partial class WoundSystem
         BackmenDamageExclusivity.RemoveInjurableIfPresent(entity);
 
         var (uid, woundable) = entity;
-
         var bone = Spawn(woundable.BoneEntity);
-        if (!TryComp<BoneComponent>(bone, out var boneComp))
+
+        Entity<BoneComponent?> boneEnt = (bone, null);
+        if (!Resolve(bone, ref boneEnt.Comp))
             return;
 
         Xform.SetParent(bone, uid);
         Containers.Insert(bone, woundable.Bone);
 
-        boneComp.BoneWoundable = uid;
+        boneEnt.Comp.BoneWoundable = uid;
     }
 
     private void OnWoundInserted(Entity<WoundComponent> ent, ref EntGotInsertedIntoContainerMessage args)
@@ -154,11 +154,10 @@ public partial class WoundSystem
                 return;
         }
 
-        var actuallyInduced = GetWoundsChanged(entity.AsNullable(), args.Origin, args.Damage);
-
         if (!_damageableQuery.TryGetComponent(woundable, out var damageable))
             return;
 
+        var actuallyInduced = GetWoundsChanged(entity, args.Origin, args.Damage);
         Damageable.ApplyDamageToDamageable(
             (woundable, damageable),
             actuallyInduced,
@@ -169,27 +168,24 @@ public partial class WoundSystem
 
     private void OnWoundableInserted(Entity<WoundableComponent> parent, ref EntInsertedIntoContainerMessage args)
     {
-        // smh
-        if (TerminatingOrDeleted(parent) || parent.Owner == EntityUid.Invalid)
+        if (TerminatingOrDeleted(parent))
             return;
 
-        var (parentEntity, parentWoundable) = parent;
         if (!TryComp<WoundableComponent>(args.Entity, out var childWoundable))
             return;
-
-        InternalAddWoundableToParent(parentEntity, args.Entity, parentWoundable, childWoundable);
+        InternalAddWoundableToParent(parent, (args.Entity, childWoundable));
     }
 
     private void OnWoundableRemoved(Entity<WoundableComponent> parent, ref EntRemovedFromContainerMessage args)
     {
-        if (TerminatingOrDeleted(parent) || parent.Owner == EntityUid.Invalid)
+        if (TerminatingOrDeleted(parent))
             return;
 
         var (parentEntity, parentWoundable) = parent;
         if (!TryComp<WoundableComponent>(args.Entity, out var childWoundable))
             return;
 
-        InternalRemoveWoundableFromParent(parentEntity, args.Entity, parentWoundable, childWoundable);
+        InternalRemoveWoundableFromParent(parent, (args.Entity, childWoundable));
     }
 
     private void OnWoundableSeverityChanged(Entity<WoundableComponent> entity, ref WoundableSeverityChangedEvent args)
@@ -198,39 +194,14 @@ public partial class WoundSystem
         if (args.NewSeverity != WoundableSeverity.Loss || TerminatingOrDeleted(uid))
             return;
 
-        if (TryGetWoundableBody(uid, out var bodyUid)
-            && TryComp<BkmDetachedBodyComponent>(bodyUid, out var detached)
-            && detached.RootOrgan == uid)
-        {
-            if (_net.IsServer && ShouldBurnToAsh(entity.AsNullable()))
-            {
-                var burnEv = new BurnDetachedBundleRootRequestEvent();
-                RaiseLocalEvent(bodyUid, ref burnEv);
-            }
-            else
-            {
-                var gibEv = new GibDetachedBundleRequestEvent();
-                RaiseLocalEvent(bodyUid, ref gibEv);
-            }
-
-            return;
-        }
-
-        if (IsWoundableRoot(uid, component))
+        if (IsWoundableRoot(entity))
         {
             DestroyWoundable(uid, uid, component);
         }
         else
         {
-            if (component.ParentWoundable != null && TryGetWoundableBody(uid, out _))
-            {
-                DestroyWoundable(component.ParentWoundable.Value, uid, component);
-            }
-            else
-            {
-                // it will be destroyed.
-                DestroyWoundable(uid, uid, component);
-            }
+            // it will be destroyed.
+            DestroyWoundable(component.ParentWoundable ?? uid, uid, component);
         }
     }
 
@@ -385,7 +356,7 @@ public partial class WoundSystem
     }
 
     [PublicAPI]
-    public bool RollForWoundMerging(
+    public virtual bool RollForWoundMergingNullable(
         Entity<WoundComponent?> woundProgenitor,
         FixedPoint2 severity)
     {
@@ -401,28 +372,32 @@ public partial class WoundSystem
     }
 
     [PublicAPI]
+    public bool RollForWoundMerging(
+        Entity<WoundComponent> woundProgenitor,
+        FixedPoint2 severity)
+    {
+        return RollForWoundMergingNullable(woundProgenitor.AsNullable(), severity);
+    }
+
+    [PublicAPI]
     public bool CanContinueWound(
-        EntityUid uid,
+        Entity<WoundableComponent> woundableEnt,
         string id,
         FixedPoint2 severity,
         [NotNullWhen(true)] out Entity<WoundComponent>? continuableWound,
-        WoundableComponent? woundable = null,
         bool forceMerging = false)
     {
         continuableWound = null;
         if (!IsWoundPrototypeValid(id))
             return false;
 
-        if (!WoundableQuery.Resolve(uid, ref woundable))
-            return false;
-
         var proto = _prototype.Index(id);
-        foreach (var wound in GetWoundableWounds(uid, woundable))
+        foreach (var wound in GetWoundableWoundsOfDamageType(woundableEnt, id))
         {
             if (proto.ID != wound.Comp.DamageType)
                 continue;
 
-            if (severity > 0 && (!RollForWoundMerging(wound.AsNullable(), severity) || forceMerging))
+            if (severity > 0 && (!RollForWoundMerging(wound, severity) || forceMerging))
                 continue;
 
             continuableWound = wound;
@@ -474,11 +449,19 @@ public partial class WoundSystem
     /// <param name="woundEnt">The wound entity.</param>
     /// <param name="severity">Severity to set.</param>
     [PublicAPI]
-    public virtual void SetWoundSeverity(
+    public virtual void SetWoundSeverityNullable(
         Entity<WoundComponent?> woundEnt,
         FixedPoint2 severity)
     {
         // Server-only execution
+    }
+
+    [PublicAPI]
+    public void SetWoundSeverity(
+        Entity<WoundComponent> woundEnt,
+        FixedPoint2 severity)
+    {
+        SetWoundSeverityNullable(woundEnt.AsNullable(), severity);
     }
 
     /// <summary>
@@ -487,7 +470,7 @@ public partial class WoundSystem
     /// <param name="woundEnt">The wound entity.</param>
     /// <param name="severity">Severity to add.</param>
     [PublicAPI]
-    public virtual void ApplyWoundSeverity(
+    public virtual void ApplyWoundSeverityNullable(
         Entity<WoundComponent?> woundEnt,
         FixedPoint2 severity)
     {
@@ -495,15 +478,21 @@ public partial class WoundSystem
     }
 
     [PublicAPI]
-    public FixedPoint2 ApplySeverityModifiers(
-        EntityUid woundable,
-        FixedPoint2 severity,
-        WoundableComponent? component = null)
+    public void ApplyWoundSeverity(
+        Entity<WoundComponent> woundEnt,
+        FixedPoint2 severity)
     {
-        if (!WoundableQuery.Resolve(woundable, ref component))
-            return severity;
+        ApplyWoundSeverityNullable(woundEnt.AsNullable(), severity);
+    }
 
-        if (component.SeverityMultipliers.Count == 0)
+    [PublicAPI]
+    public FixedPoint2 ApplySeverityModifiersNullable(
+        Entity<WoundableComponent?> woundable,
+        FixedPoint2 severity)
+    {
+        var (uid, component) = woundable;
+        if (!WoundableQuery.Resolve(uid, ref component)
+            || component.SeverityMultipliers.Count == 0)
             return severity;
 
         var toMultiply =
@@ -512,15 +501,21 @@ public partial class WoundSystem
     }
 
     [PublicAPI]
+    public FixedPoint2 ApplySeverityModifiers(
+        Entity<WoundableComponent> woundable,
+        FixedPoint2 severity)
+    {
+        return ApplySeverityModifiersNullable(woundable.AsNullable(), severity);
+    }
+
+    [PublicAPI]
     public DamageSpecifier GetWoundsChanged(
-        Entity<WoundableComponent?> woundable,
+        Entity<WoundableComponent> woundable,
         EntityUid? origin,
         DamageSpecifier damage,
         bool performLogic = true)
     {
         var (ent, component) = woundable;
-        if (!WoundableQuery.Resolve(ent, ref component, false))
-            return new DamageSpecifier(); // Empty
 
         var damageIncreased = false;
         var actuallyInducedDamage = new DamageSpecifier(damage);
@@ -532,23 +527,21 @@ public partial class WoundSystem
         var changedWounds = new Dictionary<Entity<WoundComponent>, FixedPoint2>();
         var totalChange = FixedPoint2.Zero;
 
-        // TODO: Cache a list of wounds of a SPECIFIC damage type and pull it up, to cut down on computation costs
         foreach (var damagePiece in damage.DamageDict)
         {
             // Healing ignores healing modifiers
             var severityApplied = damagePiece.Value > 0
-                ? ApplySeverityModifiers(ent, damagePiece.Value, component)
+                ? ApplySeverityModifiers(woundable, damagePiece.Value)
                 : damagePiece.Value;
 
             if (!CanContinueWound(
-                    ent,
+                    woundable,
                     damagePiece.Key,
                     damagePiece.Value,
                     out var continuedWound,
-                    component,
                     !performLogic))
             {
-                if (damagePiece.Value <= 0 || !CanAddWound(
+                if (severityApplied <= FixedPoint2.Zero || !CanAddWound(
                         ent,
                         damagePiece.Key,
                         damagePiece.Value,
@@ -558,19 +551,11 @@ public partial class WoundSystem
                     continue;
                 }
 
-                var severity = ApplySeverityModifiers(ent, damagePiece.Value, component);
-
-                if (severity <= FixedPoint2.Zero)
-                {
-                    actuallyInducedDamage.DamageDict[damagePiece.Key] = 0;
-                    continue;
-                }
-
-                actuallyInducedDamage.DamageDict[damagePiece.Key] = severity;
+                actuallyInducedDamage.DamageDict[damagePiece.Key] = severityApplied;
                 damageIncreased = true;
 
-                woundsToAdd.Add(damagePiece.Key, severity);
-                totalChange += severity;
+                woundsToAdd.Add(damagePiece.Key, severityApplied);
+                totalChange += severityApplied;
             }
             else
             {
@@ -623,7 +608,7 @@ public partial class WoundSystem
 
             foreach (var woundToChange in changedWounds)
             {
-                ApplyWoundSeverity(woundToChange.Key.AsNullable(), woundToChange.Value);
+                ApplyWoundSeverity(woundToChange.Key, woundToChange.Value);
             }
         }
 
@@ -658,7 +643,7 @@ public partial class WoundSystem
     /// <param name="change">The severity multiplier itself</param>
     /// <param name="identifier">A string to defy this multiplier from others.</param>
     [PublicAPI]
-    public virtual bool TryAddWoundableSeverityMultiplier(
+    public virtual bool TryAddWoundableSeverityMultiplierNullable(
         Entity<WoundableComponent?> woundable,
         EntityUid owner,
         FixedPoint2 change,
@@ -666,6 +651,16 @@ public partial class WoundSystem
     {
         // Server-only execution
         return false;
+    }
+
+    [PublicAPI]
+    public bool TryAddWoundableSeverityMultiplier(
+        Entity<WoundableComponent> woundable,
+        EntityUid owner,
+        FixedPoint2 change,
+        string identifier)
+    {
+        return TryAddWoundableSeverityMultiplierNullable(woundable.AsNullable(), owner, change, identifier);
     }
 
     /// <summary>
@@ -780,7 +775,6 @@ public partial class WoundSystem
     public Dictionary<TargetBodyPart, WoundableSeverity> GetWoundableStatesOnBody(EntityUid body)
     {
         var result = new Dictionary<TargetBodyPart, WoundableSeverity>();
-
         foreach (var part in SharedTargetingSystem.GetValidParts())
         {
             result[part] = WoundableSeverity.Loss;
@@ -804,7 +798,6 @@ public partial class WoundSystem
     public Dictionary<TargetBodyPart, WoundableSeverity> GetWoundableStatesOnBodyPainFeels(EntityUid body)
     {
         var result = new Dictionary<TargetBodyPart, WoundableSeverity>();
-
         foreach (var part in SharedTargetingSystem.GetValidParts())
         {
             result[part] = WoundableSeverity.Loss;
@@ -865,18 +858,25 @@ public partial class WoundSystem
         }
     }
 
-    private static WoundableSeverity WorseSeverity(WoundableSeverity current, WoundableSeverity incoming) =>
-        (WoundableSeverity) Math.Max((byte) current, (byte) incoming);
+    /// <summary>
+    /// Check if this woundable is root
+    /// </summary>
+    /// <param name="woundableEntity">Owner of the woundable</param>
+    /// <returns>true if the woundable is the root of the hierarchy</returns>
+    public bool IsWoundableRootNullable(Entity<WoundableComponent?> woundableEntity)
+    {
+        return WoundableQuery.Resolve(woundableEntity.Owner, ref woundableEntity.Comp)
+               && woundableEntity.Comp.RootWoundable == woundableEntity.Owner;
+    }
 
     /// <summary>
     /// Check if this woundable is root
     /// </summary>
     /// <param name="woundableEntity">Owner of the woundable</param>
-    /// <param name="woundable">woundable component</param>
     /// <returns>true if the woundable is the root of the hierarchy</returns>
-    public bool IsWoundableRoot(EntityUid woundableEntity, WoundableComponent? woundable = null)
+    public bool IsWoundableRoot(Entity<WoundableComponent> woundableEntity)
     {
-        return WoundableQuery.Resolve(woundableEntity, ref woundable, false) && woundable.RootWoundable == woundableEntity;
+        return IsWoundableRootNullable(woundableEntity.AsNullable());
     }
 
     public IEnumerable<Entity<WoundComponent>> GetBodyWounds(
@@ -886,9 +886,12 @@ public partial class WoundSystem
         if (!Resolve(body, ref comp))
             yield break;
 
-        foreach (var woundableUid in Body.GetWoundableTargets(body, comp))
+        if (!comp.ComplexBody)
+            yield break;
+
+        foreach (var woundableEnt in Body.GetWoundableTargets(body, comp))
         {
-            foreach (var value in GetWoundableWounds(woundableUid))
+            foreach (var value in GetWoundableWounds(woundableEnt))
             {
                 yield return value;
             }
@@ -933,46 +936,52 @@ public partial class WoundSystem
     /// <summary>
     /// Gets all woundable children of a specified woundable
     /// </summary>
-    /// <param name="targetEntity">Owner of the woundable</param>
-    /// <param name="targetWoundable"></param>
+    /// <param name="woundableEnt">Owner of the woundable</param>
     /// <returns>Enumerable to the found children</returns>
-    public IEnumerable<Entity<WoundableComponent>> GetAllWoundableChildren(
-        EntityUid targetEntity,
-        WoundableComponent? targetWoundable = null)
+    public IEnumerable<Entity<WoundableComponent>> GetAllWoundableChildrenNullable(
+        Entity<WoundableComponent?> woundableEnt)
     {
+        var (targetEntity, targetWoundable) = woundableEnt;
         if (!WoundableQuery.Resolve(targetEntity, ref targetWoundable, false))
             yield break;
 
-        foreach (var childEntity in targetWoundable.ChildWoundables)
+        foreach (var value in
+                 targetWoundable.ChildWoundables.SelectMany(woundable =>
+                     GetAllWoundableChildrenNullable(woundable)))
         {
-            if (!TryComp(childEntity, out WoundableComponent? childWoundable))
-                continue;
-            foreach (var value in GetAllWoundableChildren(childEntity, childWoundable))
-            {
-                yield return value;
-            }
+            yield return value;
         }
 
         yield return (targetEntity, targetWoundable);
     }
 
     /// <summary>
+    /// Gets all woundable children of a specified woundable
+    /// </summary>
+    /// <param name="woundableEnt"></param>
+    /// <returns></returns>
+    public IEnumerable<Entity<WoundableComponent>> GetAllWoundableChildren(
+        Entity<WoundableComponent> woundableEnt)
+    {
+        return GetAllWoundableChildrenNullable(woundableEnt.AsNullable());
+    }
+
+    /// <summary>
     /// Finds all children of a specified woundable that have a specific component
     /// </summary>
-    /// <param name="targetEntity"></param>
-    /// <param name="targetWoundable"></param>
+    /// <param name="woundable">The entity that owns woundable</param>
     /// <typeparam name="T">the type of the component we want to find</typeparam>
     /// <returns>Enumerable to the found children</returns>
-    public IEnumerable<Entity<WoundableComponent, T>> GetAllWoundableChildrenWithComp<T>(
-        EntityUid targetEntity,
-        WoundableComponent? targetWoundable = null) where T: Component, new()
+    public IEnumerable<Entity<WoundableComponent, T>> GetAllWoundableChildrenWithCompNullable<T>(
+        Entity<WoundableComponent?> woundable) where T: Component, new()
     {
+        var (targetEntity, targetWoundable) = woundable;
         if (!WoundableQuery.Resolve(targetEntity, ref targetWoundable, false))
             yield break;
 
-        foreach (var (childEntity, childWoundable) in GetAllWoundableChildren(targetEntity, targetWoundable))
+        foreach (var child in GetAllWoundableChildrenNullable(woundable))
         {
-            foreach (var value in GetAllWoundableChildrenWithComp<T>(childEntity, childWoundable))
+            foreach (var value in GetAllWoundableChildrenWithComp<T>(child))
             {
                 yield return value;
             }
@@ -984,89 +993,103 @@ public partial class WoundSystem
         yield return (targetEntity, targetWoundable,foundComp);
     }
 
-    /// <summary>
-    /// Retrieves a wound of a specific damage type
-    /// </summary>
-    /// <param name="targetEntity"></param>
-    /// <param name="wound"></param>
-    /// <param name="targetWoundable"></param>
-    /// <param name="damageType"></param>
-    /// <returns>The said wound</returns>
-    public bool TryGetWoundOfDamageType(
-        EntityUid targetEntity,
-        string damageType,
-        [NotNullWhen(true)] out Entity<WoundComponent>? wound,
-        WoundableComponent? targetWoundable = null)
+    [PublicAPI]
+    public IEnumerable<Entity<WoundableComponent, T>> GetAllWoundableChildrenWithComp<T>(
+        Entity<WoundableComponent> woundable) where T: Component, new()
     {
-        wound = null;
-        if (!WoundableQuery.Resolve(targetEntity, ref targetWoundable, false))
-            return false;
-
-        foreach (var fWound in GetWoundableWounds(targetEntity, targetWoundable))
-        {
-            if (fWound.Comp.DamageType != damageType)
-                continue;
-
-            wound = fWound;
-            return true;
-        }
-
-        return false;
+        return GetAllWoundableChildrenWithCompNullable<T>(woundable.AsNullable());
     }
 
     /// <summary>
     /// Retrieves all wounds associated with a specified entity.
     /// </summary>
-    /// <param name="targetEntity">The UID of the target entity.</param>
-    /// <param name="targetWoundable">Optional: The WoundableComponent of the target entity.</param>
+    /// <param name="targetWoundable">The entity that owns the woundable.</param>
     /// <returns>An enumerable collection of tuples containing EntityUid and WoundComponent pairs.</returns>
-    public IEnumerable<Entity<WoundComponent>> GetAllWounds(
-        EntityUid targetEntity,
-        WoundableComponent? targetWoundable = null)
+    public IEnumerable<Entity<WoundComponent>> GetAllWoundsNullable(
+        Entity<WoundableComponent?> targetWoundable)
     {
-        if (!WoundableQuery.Resolve(targetEntity, ref targetWoundable, false))
+        var (uid, comp) = targetWoundable;
+        if (!WoundableQuery.Resolve(uid, ref comp, false))
             yield break;
 
-        foreach (var (ent, childWoundable) in GetAllWoundableChildren(targetEntity, targetWoundable))
+        foreach (var child in GetAllWoundableChildrenNullable(targetWoundable))
         {
-            foreach (var woundEntity in GetWoundableWounds(ent, childWoundable))
+            foreach (var woundEntity in GetWoundableWounds(child))
             {
                 yield return (woundEntity, woundEntity);
             }
         }
     }
 
+    [PublicAPI]
+    public IEnumerable<Entity<WoundComponent>> GetAllWounds(
+        Entity<WoundableComponent> targetWoundable)
+    {
+        return GetAllWoundsNullable(targetWoundable.AsNullable());
+    }
+
     /// <summary>
     /// Retrieves all wounds associated with a specified entity, and a component.
     /// </summary>
-    /// <param name="targetEntity">The UID of the target entity.</param>
-    /// <param name="targetWoundable">Optional: The WoundableComponent of the target entity.</param>
+    /// <param name="woundable">The entity that owns the woundable.</param>
     /// <returns>An enumerable collection of tuples containing EntityUid and WoundComponent, and T component pairs.</returns>
-    public IEnumerable<Entity<WoundComponent, T>> GetAllWoundsWithComp<T>(
-        EntityUid targetEntity,
-        WoundableComponent? targetWoundable = null) where T: Component, new()
+    public IEnumerable<Entity<WoundComponent, T>> GetAllWoundsWithCompNullable<T>(
+        Entity<WoundableComponent?> woundable) where T: Component, new()
     {
+        var (targetEntity, targetWoundable) = woundable;
         if (!WoundableQuery.Resolve(targetEntity, ref targetWoundable, false))
             yield break;
 
-        foreach (var (ent, childWoundable) in GetAllWoundableChildren(targetEntity, targetWoundable))
+        foreach (var child in GetAllWoundableChildrenNullable(woundable))
         {
-            foreach (var woundEntity in GetWoundableWoundsWithComp<T>(ent, childWoundable))
+            foreach (var woundEntity in GetWoundableWoundsWithComp<T>(child))
             {
                 yield return woundEntity;
             }
         }
     }
 
+    [PublicAPI]
+    public IEnumerable<Entity<WoundComponent>> GetWoundableWoundsOfDamageTypeNullable(
+        Entity<WoundableComponent?> woundable,
+        string damageType)
+    {
+        var (targetEntity, targetWoundable) = woundable;
+        if (!WoundableQuery.Resolve(targetEntity, ref targetWoundable))
+            yield break;
+
+        foreach (var wound in GetWoundableWounds((targetEntity, targetWoundable)))
+        {
+            if (wound.Comp.DamageType != damageType)
+                continue;
+            yield return wound;
+        }
+    }
+
+    [PublicAPI]
+    public IEnumerable<Entity<WoundComponent>> GetWoundableWoundsOfDamageType(
+        Entity<WoundableComponent> woundable,
+        string damageType)
+    {
+        return GetWoundableWoundsOfDamageTypeNullable(woundable.AsNullable(), damageType);
+    }
+
+    [PublicAPI]
+    public IEnumerable<Entity<WoundComponent, T>> GetAllWoundsWithComp<T>(
+        Entity<WoundableComponent> woundable) where T: Component, new()
+    {
+        return GetAllWoundsWithCompNullable<T>(woundable.AsNullable());
+    }
+
     /// <summary>
     /// Get the wounds present on a specific woundable
     /// </summary>
-    /// <param name="targetEntity">Entity that owns the woundable</param>
-    /// <param name="targetWoundable">Woundable component</param>
+    /// <param name="woundableEnt">Entity that owns the woundable</param>
     /// <returns>An enumerable pointing to one of the found wounds</returns>
-    public IEnumerable<Entity<WoundComponent>> GetWoundableWounds(EntityUid targetEntity,
-        WoundableComponent? targetWoundable = null)
+    public IEnumerable<Entity<WoundComponent>> GetWoundableWoundsNullable(
+        Entity<WoundableComponent?> woundableEnt)
     {
+        var (targetEntity, targetWoundable) = woundableEnt;
         if (!WoundableQuery.Resolve(targetEntity, ref targetWoundable, false)
             || targetWoundable.Wounds == null
             || targetWoundable.Wounds.Count == 0)
@@ -1078,28 +1101,41 @@ public partial class WoundSystem
         }
     }
 
+    [PublicAPI]
+    public IEnumerable<Entity<WoundComponent>> GetWoundableWounds(
+        Entity<WoundableComponent> woundableEnt)
+    {
+        return GetWoundableWoundsNullable(woundableEnt.AsNullable());
+    }
+
     /// <summary>
     /// Get the wounds present on a specific woundable, with a component you want
     /// </summary>
-    /// <param name="targetEntity">Entity that owns the woundable</param>
-    /// <param name="targetWoundable">Woundable component</param>
+    /// <param name="woundableEnt">Entity that owns the woundable</param>
     /// <returns>An enumerable pointing to one of the found wounds, with the said component</returns>
-    public IEnumerable<Entity<WoundComponent, T>> GetWoundableWoundsWithComp<T>(
-        EntityUid targetEntity,
-        WoundableComponent? targetWoundable = null) where T: Component, new()
+    public IEnumerable<Entity<WoundComponent, T>> GetWoundableWoundsWithCompNullable<T>(
+        Entity<WoundableComponent?> woundableEnt) where T: Component, new()
     {
+        var (targetEntity, targetWoundable) = woundableEnt;
         if (!WoundableQuery.Resolve(targetEntity, ref targetWoundable, false)
             || targetWoundable.Wounds == null
             || targetWoundable.Wounds.Count == 0)
             yield break;
 
-        foreach (var woundEntity in GetWoundableWounds(targetEntity, targetWoundable))
+        foreach (var woundEntity in GetWoundableWoundsNullable(woundableEnt))
         {
             if (!TryComp<T>(woundEntity, out var foundComponent))
                 continue;
 
             yield return (woundEntity, woundEntity, foundComponent);
         }
+    }
+
+    [PublicAPI]
+    public IEnumerable<Entity<WoundComponent, T>> GetWoundableWoundsWithComp<T>(
+        Entity<WoundableComponent> woundableEnt) where T: Component, new()
+    {
+        return GetWoundableWoundsWithCompNullable<T>(woundableEnt.AsNullable());
     }
 
     /// <summary>
@@ -1123,13 +1159,13 @@ public partial class WoundSystem
 
         if (healable)
         {
-            return GetWoundableWounds(targetEntity, targetWoundable)
+            return GetWoundableWoundsNullable((targetEntity, targetWoundable))
                 .Where(wound => wound.Comp.DamageGroup?.ID == damageGroup || damageGroup == null)
                 .Where(wound => CanHealWound(wound))
                 .Aggregate(FixedPoint2.Zero, (current, wound) => current + wound.Comp.WoundSeverityPoint);
         }
 
-        return GetWoundableWounds(targetEntity, targetWoundable)
+        return GetWoundableWoundsNullable((targetEntity, targetWoundable))
             .Where(wound => wound.Comp.DamageGroup?.ID == damageGroup || damageGroup == null)
             .Aggregate(FixedPoint2.Zero, (current, wound) => current + wound.Comp.WoundSeverityPoint);
     }
@@ -1137,7 +1173,7 @@ public partial class WoundSystem
     /// <summary>
     /// Whether heat wounds dominated the integrity loss enough to burn this woundable to ash.
     /// </summary>
-    public bool ShouldBurnToAsh(Entity<WoundableComponent?> woundable, float burnDominanceRatio = DefaultBurnDominanceRatio)
+    public bool ShouldBurnToAshNullable(Entity<WoundableComponent?> woundable, float burnDominanceRatio = DefaultBurnDominanceRatio)
     {
         if (HasComp<BrainComponent>(woundable))
             return false;
@@ -1146,7 +1182,7 @@ public partial class WoundSystem
         if (!WoundableQuery.Resolve(ent, ref component, false))
             return false;
 
-        var activeWounds = GetWoundableWounds(woundable, component)
+        var activeWounds = GetWoundableWoundsNullable(woundable)
             .Where(wound => !wound.Comp.IsScar)
             .ToList();
 
@@ -1163,22 +1199,28 @@ public partial class WoundSystem
         return heatIntegrity >= lostIntegrity * ratio;
     }
 
+    [PublicAPI]
+    public bool ShouldBurnToAsh(Entity<WoundableComponent> woundable, float burnDominanceRatio = DefaultBurnDominanceRatio)
+    {
+        return ShouldBurnToAshNullable(woundable.AsNullable(), burnDominanceRatio);
+    }
+
     private FixedPoint2 GetBurnDominantIntegrityDamage(Entity<WoundableComponent?> woundableEnt)
     {
         var (woundable, component) = woundableEnt;
         if (!WoundableQuery.Resolve(woundable, ref component, false))
             return FixedPoint2.Zero;
 
-        var fromGroup = GetWoundableIntegrityDamage(woundableEnt, BurnDamageGroup);
+        var fromGroup = GetWoundableIntegrityDamageNullable(woundableEnt, BurnDamageGroup);
         if (fromGroup > FixedPoint2.Zero)
             return fromGroup;
 
-        return GetWoundableWounds(woundable, component)
+        return GetWoundableWoundsNullable(woundableEnt)
             .Where(wound => BurnDamageTypes.Contains(wound.Comp.DamageType))
             .Aggregate(FixedPoint2.Zero, (current, wound) => current + wound.Comp.WoundIntegrityDamage);
     }
 
-    public FixedPoint2 GetWoundableIntegrityDamage(
+    public FixedPoint2 GetWoundableIntegrityDamageNullable(
         Entity<WoundableComponent?> woundable,
         string? damageGroup = null,
         bool healable = false)
@@ -1191,15 +1233,24 @@ public partial class WoundSystem
 
         if (healable)
         {
-            return GetWoundableWounds(targetEntity, targetWoundable)
+            return GetWoundableWoundsNullable(woundable)
                 .Where(wound => wound.Comp.DamageGroup?.ID == damageGroup || damageGroup == null)
                 .Where(wound => CanHealWound(wound))
                 .Aggregate(FixedPoint2.Zero, (current, wound) => current + wound.Comp.WoundIntegrityDamage);
         }
 
-        return GetWoundableWounds(targetEntity, targetWoundable)
+        return GetWoundableWoundsNullable(woundable)
             .Where(wound => wound.Comp.DamageGroup?.ID == damageGroup || damageGroup == null)
             .Aggregate(FixedPoint2.Zero, (current, wound) => current + wound.Comp.WoundIntegrityDamage);
+    }
+
+    [PublicAPI]
+    public FixedPoint2 GetWoundableIntegrityDamage(
+        Entity<WoundableComponent> woundable,
+        string? damageGroup = null,
+        bool healable = false)
+    {
+        return GetWoundableIntegrityDamageNullable(woundable.AsNullable(), damageGroup, healable);
     }
 
 

--- a/Content.Shared/Backmen/Surgery/Wounds/Systems/WoundSystem.Wounding.cs
+++ b/Content.Shared/Backmen/Surgery/Wounds/Systems/WoundSystem.Wounding.cs
@@ -181,7 +181,6 @@ public partial class WoundSystem
         if (TerminatingOrDeleted(parent))
             return;
 
-        var (parentEntity, parentWoundable) = parent;
         if (!TryComp<WoundableComponent>(args.Entity, out var childWoundable))
             return;
 
@@ -194,14 +193,14 @@ public partial class WoundSystem
         if (args.NewSeverity != WoundableSeverity.Loss || TerminatingOrDeleted(uid))
             return;
 
-        if (IsWoundableRoot(entity))
+        if (IsWoundableRoot(entity.AsNullable()))
         {
-            DestroyWoundable(uid, uid, component);
+            DestroyWoundable(entity.AsNullable(), entity.AsNullable());
         }
         else
         {
             // it will be destroyed.
-            DestroyWoundable(component.ParentWoundable ?? uid, uid, component);
+            DestroyWoundable(component.ParentWoundable ?? entity, entity.AsNullable());
         }
     }
 
@@ -337,7 +336,7 @@ public partial class WoundSystem
     /// </summary>
     /// <param name="uid">UID of the woundable (body part).</param>
     /// <param name="woundProtoId">Wound prototype.</param>
-    /// <param name="severity">Severity for wound to apply.</param>
+    /// <param name="severity">Severity for the wound to apply.</param>
     /// <param name="woundCreated">The wound that was created</param>
     /// <param name="damageGroup"></param>
     /// <param name="woundable">Woundable component.</param>
@@ -356,7 +355,7 @@ public partial class WoundSystem
     }
 
     [PublicAPI]
-    public virtual bool RollForWoundMergingNullable(
+    public virtual bool RollForWoundMerging(
         Entity<WoundComponent?> woundProgenitor,
         FixedPoint2 severity)
     {
@@ -372,14 +371,6 @@ public partial class WoundSystem
     }
 
     [PublicAPI]
-    public bool RollForWoundMerging(
-        Entity<WoundComponent> woundProgenitor,
-        FixedPoint2 severity)
-    {
-        return RollForWoundMergingNullable(woundProgenitor.AsNullable(), severity);
-    }
-
-    [PublicAPI]
     public bool CanContinueWound(
         Entity<WoundableComponent> woundableEnt,
         string id,
@@ -392,12 +383,12 @@ public partial class WoundSystem
             return false;
 
         var proto = _prototype.Index(id);
-        foreach (var wound in GetWoundableWoundsOfDamageType(woundableEnt, id))
+        foreach (var wound in GetWoundableWoundsOfDamageType(woundableEnt.AsNullable(), id))
         {
             if (proto.ID != wound.Comp.DamageType)
                 continue;
 
-            if (severity > 0 && (!RollForWoundMerging(wound, severity) || forceMerging))
+            if (severity > 0 && (!RollForWoundMerging(wound.AsNullable(), severity) || forceMerging))
                 continue;
 
             continuableWound = wound;
@@ -449,19 +440,11 @@ public partial class WoundSystem
     /// <param name="woundEnt">The wound entity.</param>
     /// <param name="severity">Severity to set.</param>
     [PublicAPI]
-    public virtual void SetWoundSeverityNullable(
+    public virtual void SetWoundSeverity(
         Entity<WoundComponent?> woundEnt,
         FixedPoint2 severity)
     {
         // Server-only execution
-    }
-
-    [PublicAPI]
-    public void SetWoundSeverity(
-        Entity<WoundComponent> woundEnt,
-        FixedPoint2 severity)
-    {
-        SetWoundSeverityNullable(woundEnt.AsNullable(), severity);
     }
 
     /// <summary>
@@ -470,7 +453,7 @@ public partial class WoundSystem
     /// <param name="woundEnt">The wound entity.</param>
     /// <param name="severity">Severity to add.</param>
     [PublicAPI]
-    public virtual void ApplyWoundSeverityNullable(
+    public virtual void ApplyWoundSeverity(
         Entity<WoundComponent?> woundEnt,
         FixedPoint2 severity)
     {
@@ -478,15 +461,7 @@ public partial class WoundSystem
     }
 
     [PublicAPI]
-    public void ApplyWoundSeverity(
-        Entity<WoundComponent> woundEnt,
-        FixedPoint2 severity)
-    {
-        ApplyWoundSeverityNullable(woundEnt.AsNullable(), severity);
-    }
-
-    [PublicAPI]
-    public FixedPoint2 ApplySeverityModifiersNullable(
+    public FixedPoint2 ApplySeverityModifiers(
         Entity<WoundableComponent?> woundable,
         FixedPoint2 severity)
     {
@@ -498,14 +473,6 @@ public partial class WoundSystem
         var toMultiply =
             component.SeverityMultipliers.Sum(multiplier => (float) multiplier.Value.Change) / component.SeverityMultipliers.Count;
         return severity * toMultiply;
-    }
-
-    [PublicAPI]
-    public FixedPoint2 ApplySeverityModifiers(
-        Entity<WoundableComponent> woundable,
-        FixedPoint2 severity)
-    {
-        return ApplySeverityModifiersNullable(woundable.AsNullable(), severity);
     }
 
     [PublicAPI]
@@ -531,7 +498,7 @@ public partial class WoundSystem
         {
             // Healing ignores healing modifiers
             var severityApplied = damagePiece.Value > 0
-                ? ApplySeverityModifiers(woundable, damagePiece.Value)
+                ? ApplySeverityModifiers(woundable.AsNullable(), damagePiece.Value)
                 : damagePiece.Value;
 
             if (!CanContinueWound(
@@ -608,7 +575,7 @@ public partial class WoundSystem
 
             foreach (var woundToChange in changedWounds)
             {
-                ApplyWoundSeverity(woundToChange.Key, woundToChange.Value);
+                ApplyWoundSeverity(woundToChange.Key.AsNullable(), woundToChange.Value);
             }
         }
 
@@ -643,7 +610,7 @@ public partial class WoundSystem
     /// <param name="change">The severity multiplier itself</param>
     /// <param name="identifier">A string to defy this multiplier from others.</param>
     [PublicAPI]
-    public virtual bool TryAddWoundableSeverityMultiplierNullable(
+    public virtual bool TryAddWoundableSeverityMultiplier(
         Entity<WoundableComponent?> woundable,
         EntityUid owner,
         FixedPoint2 change,
@@ -651,16 +618,6 @@ public partial class WoundSystem
     {
         // Server-only execution
         return false;
-    }
-
-    [PublicAPI]
-    public bool TryAddWoundableSeverityMultiplier(
-        Entity<WoundableComponent> woundable,
-        EntityUid owner,
-        FixedPoint2 change,
-        string identifier)
-    {
-        return TryAddWoundableSeverityMultiplierNullable(woundable.AsNullable(), owner, change, identifier);
     }
 
     /// <summary>
@@ -702,13 +659,9 @@ public partial class WoundSystem
     /// </summary>
     /// <param name="parentWoundableEntity">Parent of the woundable entity. Yes.</param>
     /// <param name="woundableEntity">The entity containing the vulnerable body part</param>
-    /// <param name="woundableComp">Woundable component of woundableEntity.</param>
-    /// <param name="parentWoundableComp">Woundable component of parentWoundableEntity</param>
     public virtual void DestroyWoundable(
-        EntityUid parentWoundableEntity,
-        EntityUid woundableEntity,
-        WoundableComponent? woundableComp = null,
-        WoundableComponent? parentWoundableComp = null)
+        Entity<WoundableComponent?> parentWoundableEntity,
+        Entity<WoundableComponent?> woundableEntity)
     {
         // Server-only execution :pray:
     }
@@ -718,13 +671,9 @@ public partial class WoundSystem
     /// </summary>
     /// <param name="parentWoundableEntity">Parent of the woundable entity. Yes.</param>
     /// <param name="woundableEntity">The entity containing the vulnerable body part</param>
-    /// <param name="woundableComp">Woundable component of woundableEntity.</param>
-    /// <param name="parentWoundableComp">Woundable component of parentWoundableEntity.</param>
     public virtual void AmputateWoundable(
-        EntityUid parentWoundableEntity,
-        EntityUid woundableEntity,
-        WoundableComponent? woundableComp = null,
-        WoundableComponent? parentWoundableComp = null)
+        Entity<WoundableComponent?> parentWoundableEntity,
+        Entity<WoundableComponent?> woundableEntity)
     {
         // Server-only execution
     }
@@ -863,20 +812,10 @@ public partial class WoundSystem
     /// </summary>
     /// <param name="woundableEntity">Owner of the woundable</param>
     /// <returns>true if the woundable is the root of the hierarchy</returns>
-    public bool IsWoundableRootNullable(Entity<WoundableComponent?> woundableEntity)
+    public bool IsWoundableRoot(Entity<WoundableComponent?> woundableEntity)
     {
         return WoundableQuery.Resolve(woundableEntity.Owner, ref woundableEntity.Comp)
                && woundableEntity.Comp.RootWoundable == woundableEntity.Owner;
-    }
-
-    /// <summary>
-    /// Check if this woundable is root
-    /// </summary>
-    /// <param name="woundableEntity">Owner of the woundable</param>
-    /// <returns>true if the woundable is the root of the hierarchy</returns>
-    public bool IsWoundableRoot(Entity<WoundableComponent> woundableEntity)
-    {
-        return IsWoundableRootNullable(woundableEntity.AsNullable());
     }
 
     public IEnumerable<Entity<WoundComponent>> GetBodyWounds(
@@ -891,7 +830,7 @@ public partial class WoundSystem
 
         foreach (var woundableEnt in Body.GetWoundableTargets(body, comp))
         {
-            foreach (var value in GetWoundableWounds(woundableEnt))
+            foreach (var value in GetWoundableWounds(woundableEnt.AsNullable()))
             {
                 yield return value;
             }
@@ -938,7 +877,7 @@ public partial class WoundSystem
     /// </summary>
     /// <param name="woundableEnt">Owner of the woundable</param>
     /// <returns>Enumerable to the found children</returns>
-    public IEnumerable<Entity<WoundableComponent>> GetAllWoundableChildrenNullable(
+    public IEnumerable<Entity<WoundableComponent>> GetAllWoundableChildren(
         Entity<WoundableComponent?> woundableEnt)
     {
         var (targetEntity, targetWoundable) = woundableEnt;
@@ -947,7 +886,7 @@ public partial class WoundSystem
 
         foreach (var value in
                  targetWoundable.ChildWoundables.SelectMany(woundable =>
-                     GetAllWoundableChildrenNullable(woundable)))
+                     GetAllWoundableChildren(woundable)))
         {
             yield return value;
         }
@@ -956,32 +895,21 @@ public partial class WoundSystem
     }
 
     /// <summary>
-    /// Gets all woundable children of a specified woundable
-    /// </summary>
-    /// <param name="woundableEnt"></param>
-    /// <returns></returns>
-    public IEnumerable<Entity<WoundableComponent>> GetAllWoundableChildren(
-        Entity<WoundableComponent> woundableEnt)
-    {
-        return GetAllWoundableChildrenNullable(woundableEnt.AsNullable());
-    }
-
-    /// <summary>
     /// Finds all children of a specified woundable that have a specific component
     /// </summary>
     /// <param name="woundable">The entity that owns woundable</param>
     /// <typeparam name="T">the type of the component we want to find</typeparam>
     /// <returns>Enumerable to the found children</returns>
-    public IEnumerable<Entity<WoundableComponent, T>> GetAllWoundableChildrenWithCompNullable<T>(
+    public IEnumerable<Entity<WoundableComponent, T>> GetAllWoundableChildrenWithComp<T>(
         Entity<WoundableComponent?> woundable) where T: Component, new()
     {
         var (targetEntity, targetWoundable) = woundable;
         if (!WoundableQuery.Resolve(targetEntity, ref targetWoundable, false))
             yield break;
 
-        foreach (var child in GetAllWoundableChildrenNullable(woundable))
+        foreach (var child in GetAllWoundableChildren(woundable))
         {
-            foreach (var value in GetAllWoundableChildrenWithComp<T>(child))
+            foreach (var value in GetAllWoundableChildrenWithComp<T>(child.AsNullable()))
             {
                 yield return value;
             }
@@ -993,39 +921,25 @@ public partial class WoundSystem
         yield return (targetEntity, targetWoundable,foundComp);
     }
 
-    [PublicAPI]
-    public IEnumerable<Entity<WoundableComponent, T>> GetAllWoundableChildrenWithComp<T>(
-        Entity<WoundableComponent> woundable) where T: Component, new()
-    {
-        return GetAllWoundableChildrenWithCompNullable<T>(woundable.AsNullable());
-    }
-
     /// <summary>
     /// Retrieves all wounds associated with a specified entity.
     /// </summary>
     /// <param name="targetWoundable">The entity that owns the woundable.</param>
     /// <returns>An enumerable collection of tuples containing EntityUid and WoundComponent pairs.</returns>
-    public IEnumerable<Entity<WoundComponent>> GetAllWoundsNullable(
+    public IEnumerable<Entity<WoundComponent>> GetAllWounds(
         Entity<WoundableComponent?> targetWoundable)
     {
         var (uid, comp) = targetWoundable;
         if (!WoundableQuery.Resolve(uid, ref comp, false))
             yield break;
 
-        foreach (var child in GetAllWoundableChildrenNullable(targetWoundable))
+        foreach (var child in GetAllWoundableChildren(targetWoundable))
         {
-            foreach (var woundEntity in GetWoundableWounds(child))
+            foreach (var woundEntity in GetWoundableWounds(child.AsNullable()))
             {
                 yield return (woundEntity, woundEntity);
             }
         }
-    }
-
-    [PublicAPI]
-    public IEnumerable<Entity<WoundComponent>> GetAllWounds(
-        Entity<WoundableComponent> targetWoundable)
-    {
-        return GetAllWoundsNullable(targetWoundable.AsNullable());
     }
 
     /// <summary>
@@ -1033,16 +947,16 @@ public partial class WoundSystem
     /// </summary>
     /// <param name="woundable">The entity that owns the woundable.</param>
     /// <returns>An enumerable collection of tuples containing EntityUid and WoundComponent, and T component pairs.</returns>
-    public IEnumerable<Entity<WoundComponent, T>> GetAllWoundsWithCompNullable<T>(
+    public IEnumerable<Entity<WoundComponent, T>> GetAllWoundsWithComp<T>(
         Entity<WoundableComponent?> woundable) where T: Component, new()
     {
         var (targetEntity, targetWoundable) = woundable;
         if (!WoundableQuery.Resolve(targetEntity, ref targetWoundable, false))
             yield break;
 
-        foreach (var child in GetAllWoundableChildrenNullable(woundable))
+        foreach (var child in GetAllWoundableChildren(woundable))
         {
-            foreach (var woundEntity in GetWoundableWoundsWithComp<T>(child))
+            foreach (var woundEntity in GetWoundableWoundsWithComp<T>(child.AsNullable()))
             {
                 yield return woundEntity;
             }
@@ -1050,7 +964,7 @@ public partial class WoundSystem
     }
 
     [PublicAPI]
-    public IEnumerable<Entity<WoundComponent>> GetWoundableWoundsOfDamageTypeNullable(
+    public IEnumerable<Entity<WoundComponent>> GetWoundableWoundsOfDamageType(
         Entity<WoundableComponent?> woundable,
         string damageType)
     {
@@ -1066,27 +980,12 @@ public partial class WoundSystem
         }
     }
 
-    [PublicAPI]
-    public IEnumerable<Entity<WoundComponent>> GetWoundableWoundsOfDamageType(
-        Entity<WoundableComponent> woundable,
-        string damageType)
-    {
-        return GetWoundableWoundsOfDamageTypeNullable(woundable.AsNullable(), damageType);
-    }
-
-    [PublicAPI]
-    public IEnumerable<Entity<WoundComponent, T>> GetAllWoundsWithComp<T>(
-        Entity<WoundableComponent> woundable) where T: Component, new()
-    {
-        return GetAllWoundsWithCompNullable<T>(woundable.AsNullable());
-    }
-
     /// <summary>
     /// Get the wounds present on a specific woundable
     /// </summary>
     /// <param name="woundableEnt">Entity that owns the woundable</param>
     /// <returns>An enumerable pointing to one of the found wounds</returns>
-    public IEnumerable<Entity<WoundComponent>> GetWoundableWoundsNullable(
+    public IEnumerable<Entity<WoundComponent>> GetWoundableWounds(
         Entity<WoundableComponent?> woundableEnt)
     {
         var (targetEntity, targetWoundable) = woundableEnt;
@@ -1100,20 +999,12 @@ public partial class WoundSystem
             yield return (woundEntity, WoundQuery.Comp(woundEntity));
         }
     }
-
-    [PublicAPI]
-    public IEnumerable<Entity<WoundComponent>> GetWoundableWounds(
-        Entity<WoundableComponent> woundableEnt)
-    {
-        return GetWoundableWoundsNullable(woundableEnt.AsNullable());
-    }
-
     /// <summary>
     /// Get the wounds present on a specific woundable, with a component you want
     /// </summary>
     /// <param name="woundableEnt">Entity that owns the woundable</param>
     /// <returns>An enumerable pointing to one of the found wounds, with the said component</returns>
-    public IEnumerable<Entity<WoundComponent, T>> GetWoundableWoundsWithCompNullable<T>(
+    public IEnumerable<Entity<WoundComponent, T>> GetWoundableWoundsWithComp<T>(
         Entity<WoundableComponent?> woundableEnt) where T: Component, new()
     {
         var (targetEntity, targetWoundable) = woundableEnt;
@@ -1122,20 +1013,13 @@ public partial class WoundSystem
             || targetWoundable.Wounds.Count == 0)
             yield break;
 
-        foreach (var woundEntity in GetWoundableWoundsNullable(woundableEnt))
+        foreach (var woundEntity in GetWoundableWounds(woundableEnt))
         {
             if (!TryComp<T>(woundEntity, out var foundComponent))
                 continue;
 
             yield return (woundEntity, woundEntity, foundComponent);
         }
-    }
-
-    [PublicAPI]
-    public IEnumerable<Entity<WoundComponent, T>> GetWoundableWoundsWithComp<T>(
-        Entity<WoundableComponent> woundableEnt) where T: Component, new()
-    {
-        return GetWoundableWoundsWithCompNullable<T>(woundableEnt.AsNullable());
     }
 
     /// <summary>
@@ -1159,13 +1043,13 @@ public partial class WoundSystem
 
         if (healable)
         {
-            return GetWoundableWoundsNullable((targetEntity, targetWoundable))
+            return GetWoundableWounds((targetEntity, targetWoundable))
                 .Where(wound => wound.Comp.DamageGroup?.ID == damageGroup || damageGroup == null)
                 .Where(wound => CanHealWound(wound))
                 .Aggregate(FixedPoint2.Zero, (current, wound) => current + wound.Comp.WoundSeverityPoint);
         }
 
-        return GetWoundableWoundsNullable((targetEntity, targetWoundable))
+        return GetWoundableWounds((targetEntity, targetWoundable))
             .Where(wound => wound.Comp.DamageGroup?.ID == damageGroup || damageGroup == null)
             .Aggregate(FixedPoint2.Zero, (current, wound) => current + wound.Comp.WoundSeverityPoint);
     }
@@ -1173,7 +1057,7 @@ public partial class WoundSystem
     /// <summary>
     /// Whether heat wounds dominated the integrity loss enough to burn this woundable to ash.
     /// </summary>
-    public bool ShouldBurnToAshNullable(Entity<WoundableComponent?> woundable, float burnDominanceRatio = DefaultBurnDominanceRatio)
+    public bool ShouldBurnToAsh(Entity<WoundableComponent?> woundable, float burnDominanceRatio = DefaultBurnDominanceRatio)
     {
         if (HasComp<BrainComponent>(woundable))
             return false;
@@ -1182,7 +1066,7 @@ public partial class WoundSystem
         if (!WoundableQuery.Resolve(ent, ref component, false))
             return false;
 
-        var activeWounds = GetWoundableWoundsNullable(woundable)
+        var activeWounds = GetWoundableWounds(woundable)
             .Where(wound => !wound.Comp.IsScar)
             .ToList();
 
@@ -1199,28 +1083,22 @@ public partial class WoundSystem
         return heatIntegrity >= lostIntegrity * ratio;
     }
 
-    [PublicAPI]
-    public bool ShouldBurnToAsh(Entity<WoundableComponent> woundable, float burnDominanceRatio = DefaultBurnDominanceRatio)
-    {
-        return ShouldBurnToAshNullable(woundable.AsNullable(), burnDominanceRatio);
-    }
-
     private FixedPoint2 GetBurnDominantIntegrityDamage(Entity<WoundableComponent?> woundableEnt)
     {
         var (woundable, component) = woundableEnt;
         if (!WoundableQuery.Resolve(woundable, ref component, false))
             return FixedPoint2.Zero;
 
-        var fromGroup = GetWoundableIntegrityDamageNullable(woundableEnt, BurnDamageGroup);
+        var fromGroup = GetWoundableIntegrityDamage(woundableEnt, BurnDamageGroup);
         if (fromGroup > FixedPoint2.Zero)
             return fromGroup;
 
-        return GetWoundableWoundsNullable(woundableEnt)
+        return GetWoundableWounds(woundableEnt)
             .Where(wound => BurnDamageTypes.Contains(wound.Comp.DamageType))
             .Aggregate(FixedPoint2.Zero, (current, wound) => current + wound.Comp.WoundIntegrityDamage);
     }
 
-    public FixedPoint2 GetWoundableIntegrityDamageNullable(
+    public FixedPoint2 GetWoundableIntegrityDamage(
         Entity<WoundableComponent?> woundable,
         string? damageGroup = null,
         bool healable = false)
@@ -1233,28 +1111,18 @@ public partial class WoundSystem
 
         if (healable)
         {
-            return GetWoundableWoundsNullable(woundable)
+            return GetWoundableWounds(woundable)
                 .Where(wound => wound.Comp.DamageGroup?.ID == damageGroup || damageGroup == null)
                 .Where(wound => CanHealWound(wound))
                 .Aggregate(FixedPoint2.Zero, (current, wound) => current + wound.Comp.WoundIntegrityDamage);
         }
 
-        return GetWoundableWoundsNullable(woundable)
+        return GetWoundableWounds(woundable)
             .Where(wound => wound.Comp.DamageGroup?.ID == damageGroup || damageGroup == null)
             .Aggregate(FixedPoint2.Zero, (current, wound) => current + wound.Comp.WoundIntegrityDamage);
     }
 
-    [PublicAPI]
-    public FixedPoint2 GetWoundableIntegrityDamage(
-        Entity<WoundableComponent> woundable,
-        string? damageGroup = null,
-        bool healable = false)
-    {
-        return GetWoundableIntegrityDamageNullable(woundable.AsNullable(), damageGroup, healable);
-    }
-
-
-    private bool TryGetWoundableBody(EntityUid woundable, out EntityUid bodyUid)
+    public bool TryGetWoundableBody(EntityUid woundable, out EntityUid bodyUid)
     {
         if (TryComp<BodyPartComponent>(woundable, out var bodyPart) && bodyPart.Body is { } partBody)
         {

--- a/Content.Shared/Backmen/Surgery/Wounds/Systems/WoundSystem.Wounding.cs
+++ b/Content.Shared/Backmen/Surgery/Wounds/Systems/WoundSystem.Wounding.cs
@@ -35,6 +35,21 @@ public partial class WoundSystem
     protected EntityQuery<WoundableComponent> WoundableQuery;
     private EntityQuery<DamageableComponent> _damageableQuery;
 
+    // TODO: ideally this has to be reworked,
+    // and all "Burn" damage types should have their own behaviours along with a respective component
+    protected readonly List<ProtoId<DamageTypePrototype>> BurnDamageTypes = new()
+    {
+        "Heat",
+        "Cold",
+        "Shock",
+        "Caustic",
+    };
+
+    public const float DefaultBurnDominanceRatio = 0.75f;
+
+    private const string BurnDamageGroup = "Burn";
+    private const string HeatDamageTypeId = "Heat";
+
     private void InitWounding()
     {
         SubscribeLocalEvent<WoundableComponent, ComponentInit>(OnWoundableInit);
@@ -139,7 +154,7 @@ public partial class WoundSystem
                 return;
         }
 
-        var actuallyInduced = GetWoundsChanged(woundable, args.Origin, args.Damage, component: component);
+        var actuallyInduced = GetWoundsChanged(entity.AsNullable(), args.Origin, args.Damage);
 
         if (!_damageableQuery.TryGetComponent(woundable, out var damageable))
             return;
@@ -187,7 +202,7 @@ public partial class WoundSystem
             && TryComp<BkmDetachedBodyComponent>(bodyUid, out var detached)
             && detached.RootOrgan == uid)
         {
-            if (_net.IsServer && ShouldBurnToAsh(uid, component))
+            if (_net.IsServer && ShouldBurnToAsh(entity.AsNullable()))
             {
                 var burnEv = new BurnDetachedBundleRootRequestEvent();
                 RaiseLocalEvent(bodyUid, ref burnEv);
@@ -337,9 +352,6 @@ public partial class WoundSystem
         if (!WoundableQuery.Resolve(uid, ref woundable))
             return false;
 
-        if (woundable.Wounds == null)
-            return false;
-
         if (!woundable.AllowWounds)
             return false;
 
@@ -383,7 +395,8 @@ public partial class WoundSystem
         if (!WoundQuery.Resolve(woundProgenitor, ref woundProgenitor.Comp))
             return false;
 
-        var chance = woundProgenitor.Comp.MergeChance * (severity / _woundMergeRatio);
+        var chance =
+            FixedPoint2.Clamp(woundProgenitor.Comp.MergeChance * (severity / _woundMergeRatio), 0f, 1f);
         return Random.Prob((float) chance);
     }
 
@@ -402,16 +415,13 @@ public partial class WoundSystem
         if (!WoundableQuery.Resolve(uid, ref woundable))
             return false;
 
-        if (woundable.Wounds == null)
-            return false;
-
         var proto = _prototype.Index(id);
         foreach (var wound in GetWoundableWounds(uid, woundable))
         {
             if (proto.ID != wound.Comp.DamageType)
                 continue;
 
-            if (!RollForWoundMerging(wound.AsNullable(), severity))
+            if (severity > 0 && !RollForWoundMerging(wound.AsNullable(), severity))
                 continue;
 
             continuableWound = wound;
@@ -422,14 +432,14 @@ public partial class WoundSystem
     }
 
     /// <summary>
-    /// Continues wound with specific type, if there's any. Adds severity to it basically.
+    /// Continues wound with a specific type, if there's any. Adds severity to it basically.
     /// </summary>
     /// <param name="uid">Woundable entity's UID.</param>
     /// <param name="id">Wound entity's ID.</param>
     /// <param name="severity">Severity to apply.</param>
     /// <param name="woundContinued">The wound the severity was applied to, if any</param>
     /// <param name="woundable">Woundable for wound to add.</param>
-    /// <returns>Returns true, if wound was continued.</returns>
+    /// <returns>Returns true if a wound was continued.</returns>
     [PublicAPI]
     public virtual bool TryContinueWound(
         EntityUid uid,
@@ -460,11 +470,12 @@ public partial class WoundSystem
     /// <summary>
     /// Sets severity of a wound.
     /// </summary>
-    /// <param name="uid">UID of the wound.</param>
+    /// <param name="woundEnt">The wound entity.</param>
     /// <param name="severity">Severity to set.</param>
-    /// <param name="wound">Wound to which severity is applied.</param>
     [PublicAPI]
-    public virtual void SetWoundSeverity(EntityUid uid, FixedPoint2 severity, WoundComponent? wound = null)
+    public virtual void SetWoundSeverity(
+        Entity<WoundComponent?> woundEnt,
+        FixedPoint2 severity)
     {
         // Server-only execution
     }
@@ -472,14 +483,12 @@ public partial class WoundSystem
     /// <summary>
     /// Applies severity to a wound
     /// </summary>
-    /// <param name="uid">UID of the wound.</param>
+    /// <param name="woundEnt">The wound entity.</param>
     /// <param name="severity">Severity to add.</param>
-    /// <param name="wound">Wound to which severity is applied.</param>
     [PublicAPI]
     public virtual void ApplyWoundSeverity(
-        EntityUid uid,
-        FixedPoint2 severity,
-        WoundComponent? wound = null)
+        Entity<WoundComponent?> woundEnt,
+        FixedPoint2 severity)
     {
         // Server-only execution
     }
@@ -503,13 +512,13 @@ public partial class WoundSystem
 
     [PublicAPI]
     public DamageSpecifier GetWoundsChanged(
-        EntityUid woundable,
+        Entity<WoundableComponent?> woundable,
         EntityUid? origin,
         DamageSpecifier damage,
-        bool performLogic = true,
-        WoundableComponent? component = null)
+        bool performLogic = true)
     {
-        if (!WoundableQuery.Resolve(woundable, ref component, false))
+        var (ent, component) = woundable;
+        if (!WoundableQuery.Resolve(ent, ref component, false))
             return new DamageSpecifier(); // Empty
 
         var damageIncreased = false;
@@ -527,18 +536,18 @@ public partial class WoundSystem
         {
             // Healing ignores healing modifiers
             var severityApplied = damagePiece.Value > 0
-                ? ApplySeverityModifiers(woundable, damagePiece.Value, component)
+                ? ApplySeverityModifiers(ent, damagePiece.Value, component)
                 : damagePiece.Value;
 
             if (!CanContinueWound(
-                    woundable,
+                    ent,
                     damagePiece.Key,
                     damagePiece.Value,
                     out var continuedWound,
                     component))
             {
                 if (damagePiece.Value <= 0 || !CanAddWound(
-                        woundable,
+                        ent,
                         damagePiece.Key,
                         damagePiece.Value,
                         component))
@@ -547,7 +556,7 @@ public partial class WoundSystem
                     continue;
                 }
 
-                var severity = ApplySeverityModifiers(woundable, damagePiece.Value, component);
+                var severity = ApplySeverityModifiers(ent, damagePiece.Value, component);
 
                 if (severity <= FixedPoint2.Zero)
                 {
@@ -584,7 +593,7 @@ public partial class WoundSystem
             foreach (var woundToAdd in woundsToAdd)
             {
                 if (TryCreateWound(
-                        woundable,
+                        ent,
                         woundToAdd.Key,
                         woundToAdd.Value,
                         out var woundCreated))
@@ -595,7 +604,7 @@ public partial class WoundSystem
         }
 
         var woundsDeltaEv = new WoundsDeltaChanged(origin, totalChange, changedWounds, damageIncreased);
-        RaiseLocalEvent(woundable, ref woundsDeltaEv);
+        RaiseLocalEvent(ent, ref woundsDeltaEv);
 
         foreach (var wound in
                  changedWounds.Where(wound => addedWounds.Contains(wound.Key) || removedWounds.Contains(wound.Key)))
@@ -612,7 +621,7 @@ public partial class WoundSystem
 
             foreach (var woundToChange in changedWounds)
             {
-                ApplyWoundSeverity(woundToChange.Key, woundToChange.Value, woundToChange.Key);
+                ApplyWoundSeverity(woundToChange.Key.AsNullable(), woundToChange.Value);
             }
         }
 
@@ -640,20 +649,18 @@ public partial class WoundSystem
     }
 
     /// <summary>
-    /// Applies severity multiplier to a wound.
+    /// Applies severity multiplier to a woundable.
     /// </summary>
-    /// <param name="uid">UID of the woundable.</param>
+    /// <param name="woundable">Woundable entity.</param>
     /// <param name="owner">UID of the multiplier owner.</param>
     /// <param name="change">The severity multiplier itself</param>
     /// <param name="identifier">A string to defy this multiplier from others.</param>
-    /// <param name="component">Woundable to which severity multiplier is applied.</param>
     [PublicAPI]
     public virtual bool TryAddWoundableSeverityMultiplier(
-        EntityUid uid,
+        Entity<WoundableComponent?> woundable,
         EntityUid owner,
         FixedPoint2 change,
-        string identifier,
-        WoundableComponent? component = null)
+        string identifier)
     {
         // Server-only execution
         return false;
@@ -765,7 +772,7 @@ public partial class WoundSystem
     protected bool IsWoundPrototypeValid(string protoId)
     {
         return _prototype.TryIndex<EntityPrototype>(protoId, out var woundPrototype)
-               && woundPrototype.TryGetComponent<WoundComponent>(out _, _factory);
+               && woundPrototype.TryComp<WoundComponent>(out _, _factory);
     }
 
     public Dictionary<TargetBodyPart, WoundableSeverity> GetWoundableStatesOnBody(EntityUid body)
@@ -1020,8 +1027,6 @@ public partial class WoundSystem
 
         foreach (var (ent, childWoundable) in GetAllWoundableChildren(targetEntity, targetWoundable))
         {
-            if (childWoundable.Wounds == null)
-                continue;
             foreach (var woundEntity in GetWoundableWounds(ent, childWoundable))
             {
                 yield return (woundEntity, woundEntity);
@@ -1044,8 +1049,6 @@ public partial class WoundSystem
 
         foreach (var (ent, childWoundable) in GetAllWoundableChildren(targetEntity, targetWoundable))
         {
-            if (childWoundable.Wounds == null)
-                continue;
             foreach (var woundEntity in GetWoundableWoundsWithComp<T>(ent, childWoundable))
             {
                 yield return woundEntity;
@@ -1063,7 +1066,7 @@ public partial class WoundSystem
         WoundableComponent? targetWoundable = null)
     {
         if (!WoundableQuery.Resolve(targetEntity, ref targetWoundable, false)
-            || targetWoundable.Wounds == null || targetWoundable.Wounds.Count == 0)
+            || targetWoundable.Wounds.Count == 0)
             yield break;
 
         foreach (var woundEntity in targetWoundable.Wounds.ContainedEntities.ToList())
@@ -1083,7 +1086,7 @@ public partial class WoundSystem
         WoundableComponent? targetWoundable = null) where T: Component, new()
     {
         if (!WoundableQuery.Resolve(targetEntity, ref targetWoundable, false)
-            || targetWoundable.Wounds == null || targetWoundable.Wounds.Count == 0)
+            || targetWoundable.Wounds.Count == 0)
             yield break;
 
         foreach (var woundEntity in GetWoundableWounds(targetEntity, targetWoundable))
@@ -1110,7 +1113,7 @@ public partial class WoundSystem
         bool healable = false)
     {
         if (!WoundableQuery.Resolve(targetEntity, ref targetWoundable, false)
-            || targetWoundable.Wounds == null || targetWoundable.Wounds.Count == 0)
+            || targetWoundable.Wounds.Count == 0)
             return FixedPoint2.Zero;
 
         if (healable)
@@ -1127,67 +1130,57 @@ public partial class WoundSystem
     }
 
     /// <summary>
-    /// Returns the integrity damage the woundable has
-    /// </summary>
-    /// <param name="targetEntity">The woundable uid</param>
-    /// <param name="targetWoundable">The component</param>
-    /// <param name="damageGroup">The damage group of wounds that induced the damage</param>
-    /// <param name="healable">Is the integrity damage healable</param>
-    /// <returns>The integrity damage</returns>
-    public const float DefaultBurnDominanceRatio = 0.75f;
-
-    private const string BurnDamageGroup = "Burn";
-
-    /// <summary>
     /// Whether heat wounds dominated the integrity loss enough to burn this woundable to ash.
     /// </summary>
-    public bool ShouldBurnToAsh(EntityUid woundable, WoundableComponent? component = null)
+    public bool ShouldBurnToAsh(Entity<WoundableComponent?> woundable, float burnDominanceRatio = DefaultBurnDominanceRatio)
     {
         if (HasComp<BrainComponent>(woundable))
             return false;
 
-        if (!WoundableQuery.Resolve(woundable, ref component, false))
+        var (ent, component) = woundable;
+        if (!WoundableQuery.Resolve(ent, ref component, false))
             return false;
 
         var activeWounds = GetWoundableWounds(woundable, component)
             .Where(wound => !wound.Comp.IsScar)
             .ToList();
 
-        if (activeWounds.Count > 0 && activeWounds.All(wound => wound.Comp.DamageType == "Heat"))
+        if (activeWounds.Count > 0 && activeWounds.All(wound => wound.Comp.DamageType == HeatDamageTypeId))
             return true;
 
         var lostIntegrity = component.IntegrityCap - component.WoundableIntegrity;
         if (lostIntegrity <= FixedPoint2.Zero)
             return false;
 
-        var heatIntegrity = GetBurnDominantIntegrityDamage(woundable, component);
-        var ratio = component.BurnDominanceRatio ?? DefaultBurnDominanceRatio;
+        var heatIntegrity = GetBurnDominantIntegrityDamage(woundable);
+        var ratio = component.BurnDominanceRatio ?? burnDominanceRatio;
 
         return heatIntegrity >= lostIntegrity * ratio;
     }
 
-    private FixedPoint2 GetBurnDominantIntegrityDamage(EntityUid woundable, WoundableComponent? component = null)
+    private FixedPoint2 GetBurnDominantIntegrityDamage(Entity<WoundableComponent?> woundableEnt)
     {
-        var fromGroup = GetWoundableIntegrityDamage(woundable, component, BurnDamageGroup);
+        var (woundable, component) = woundableEnt;
+        if (!WoundableQuery.Resolve(woundable, ref component, false))
+            return FixedPoint2.Zero;
+
+        var fromGroup = GetWoundableIntegrityDamage(woundableEnt, BurnDamageGroup);
         if (fromGroup > FixedPoint2.Zero)
             return fromGroup;
 
-        if (!WoundableQuery.Resolve(woundable, ref component, false) || component.Wounds == null)
-            return FixedPoint2.Zero;
-
         return GetWoundableWounds(woundable, component)
-            .Where(wound => wound.Comp.DamageType is "Heat" or "Cold" or "Shock" or "Caustic")
+            .Where(wound => BurnDamageTypes.Contains(wound.Comp.DamageType))
             .Aggregate(FixedPoint2.Zero, (current, wound) => current + wound.Comp.WoundIntegrityDamage);
     }
 
     public FixedPoint2 GetWoundableIntegrityDamage(
-        EntityUid targetEntity,
-        WoundableComponent? targetWoundable = null,
+        Entity<WoundableComponent?> woundable,
         string? damageGroup = null,
         bool healable = false)
     {
+        var (targetEntity, targetWoundable) = woundable;
         if (!WoundableQuery.Resolve(targetEntity, ref targetWoundable, false)
-            || targetWoundable.Wounds == null || targetWoundable.Wounds.Count == 0)
+            || targetWoundable.Wounds.Count == 0)
             return FixedPoint2.Zero;
 
         if (healable)
@@ -1202,6 +1195,7 @@ public partial class WoundSystem
             .Where(wound => wound.Comp.DamageGroup?.ID == damageGroup || damageGroup == null)
             .Aggregate(FixedPoint2.Zero, (current, wound) => current + wound.Comp.WoundIntegrityDamage);
     }
+
 
     private bool TryGetWoundableBody(EntityUid woundable, out EntityUid bodyUid)
     {

--- a/Content.Shared/Backmen/Surgery/Wounds/Systems/WoundSystem.cs
+++ b/Content.Shared/Backmen/Surgery/Wounds/Systems/WoundSystem.cs
@@ -415,7 +415,7 @@ public abstract partial class WoundSystem : EntitySystem
         if (targetWoundable.ChildWoundables.Count == 0)
             return;
 
-        foreach (var (childEntity, childWoundable) in GetAllWoundableChildren(woundable))
+        foreach (var (childEntity, childWoundable) in GetAllWoundableChildren(woundable.AsNullable()))
         {
             childWoundable.RootWoundable = targetWoundable.RootWoundable;
             DirtyField(childEntity, childWoundable, nameof(WoundableComponent.RootWoundable));
@@ -442,7 +442,7 @@ public abstract partial class WoundSystem : EntitySystem
 
         RaiseLocalEvent(childUid, ref woundableAttached);
 
-        foreach (var (woundId, wound) in GetAllWounds(childEntity))
+        foreach (var (woundId, wound) in GetAllWounds(childEntity.AsNullable()))
         {
             var ev = new WoundAddedEvent(wound, parentWoundable, woundableRoot);
             RaiseLocalEvent(woundId, ref ev);
@@ -483,7 +483,7 @@ public abstract partial class WoundSystem : EntitySystem
 
         RaiseLocalEvent(childEntity, ref woundableDetached);
 
-        foreach (var (woundId, wound) in GetAllWounds(childEntity))
+        foreach (var (woundId, wound) in GetAllWounds(childEntity.AsNullable()))
         {
             var ev = new WoundRemovedEvent(wound, childWoundable, oldWoundableRoot);
             RaiseLocalEvent(woundId, ref ev);
@@ -539,7 +539,7 @@ public abstract partial class WoundSystem : EntitySystem
     protected void DestroyWoundableChildren(Entity<WoundableComponent> woundableEntity)
     {
         var (uid, _) = woundableEntity;
-        foreach (var (child, childWoundable) in GetAllWoundableChildren(woundableEntity))
+        foreach (var (child, childWoundable) in GetAllWoundableChildren(woundableEntity.AsNullable()))
         {
             if (child == uid || TerminatingOrDeleted(child))
                 continue;
@@ -547,11 +547,11 @@ public abstract partial class WoundSystem : EntitySystem
             var parent = childWoundable.ParentWoundable ?? uid;
             if (childWoundable.WoundableSeverity is WoundableSeverity.Critical)
             {
-                DestroyWoundable(parent, child, childWoundable);
+                DestroyWoundable(parent, (child, childWoundable));
                 continue;
             }
 
-            AmputateWoundable(parent, child, childWoundable);
+            AmputateWoundable(parent, (child, childWoundable));
         }
     }
 }

--- a/Content.Shared/Backmen/Surgery/Wounds/Systems/WoundSystem.cs
+++ b/Content.Shared/Backmen/Surgery/Wounds/Systems/WoundSystem.cs
@@ -53,8 +53,6 @@ public abstract partial class WoundSystem : EntitySystem
     [Dependency] protected MobStateSystem MobState = default!;
     [Dependency] protected DamageableSystem Damageable = default!;
 
-    [Dependency] private SharedPopupSystem _popup = default!;
-
     protected readonly Dictionary<WoundSeverity, FixedPoint2> WoundThresholds = new()
     {
         { WoundSeverity.Healed, 0 },
@@ -93,7 +91,7 @@ public abstract partial class WoundSystem : EntitySystem
 
     private void OnWoundableTerminating(Entity<WoundableComponent> ent, ref EntityTerminatingEvent args)
     {
-        SanitizeWoundableReferences(ent.Owner, ent.Comp);
+        //SanitizeWoundableReferences(ent.Owner, ent.Comp);
 
         if (ent.Comp.ParentWoundable is not { } parentUid
             || !WoundableQuery.TryComp(parentUid, out var parentWoundable))
@@ -149,8 +147,8 @@ public abstract partial class WoundSystem : EntitySystem
 
         if (holdingWoundable != EntityUid.Invalid)
         {
-            UpdateWoundableIntegrity(holdingWoundable);
-            CheckWoundableSeverityThresholds(holdingWoundable);
+            UpdateWoundableIntegrity((holdingWoundable, Comp<WoundableComponent>(holdingWoundable)));
+            CheckWoundableSeverityThresholds((holdingWoundable, Comp<WoundableComponent>(holdingWoundable)));
         }
 
         if (ent.Comp.WoundSeverity != old.Severity)
@@ -164,7 +162,7 @@ public abstract partial class WoundSystem : EntitySystem
 
     private void OnWoundableAfterAutoHandleState(Entity<WoundableComponent> ent, ref AfterAutoHandleStateEvent args)
     {
-        SanitizeWoundableReferences(ent.Owner, ent.Comp);
+        //SanitizeWoundableReferences(ent.Owner, ent.Comp);
 
         if (!_net.IsClient)
         {
@@ -243,11 +241,9 @@ public abstract partial class WoundSystem : EntitySystem
         wound.NetworkedDamageGroup = damageGroup?.ID;
     }
 
-    protected void CheckSeverityThresholds(Entity<WoundComponent?> wound)
+    protected void CheckSeverityThresholds(Entity<WoundComponent> wound)
     {
         var (uid, component) = wound;
-        if (!WoundQuery.Resolve(uid, ref component, false))
-            return;
 
         var nearestSeverity = component.WoundSeverity;
         foreach (var (severity, value) in WoundThresholds.OrderByDescending(kv => kv.Value))
@@ -272,17 +268,12 @@ public abstract partial class WoundSystem : EntitySystem
 
     // NOTE: THIS SHOULD BE ONLY RAISED ON A CHANGE OF VALUES. OUTSIDE OF CLASSICAL DAMAGE HANDLING LIKE HEALING
     protected void RaiseWoundEvents(
-        Entity<WoundComponent?> woundEnt,
-        Entity<WoundableComponent?> woundable,
+        Entity<WoundComponent> woundEnt,
+        Entity<WoundableComponent> woundable,
         FixedPoint2 oldSeverity)
     {
         var (woundUid, woundComp) = woundEnt;
-        if (!WoundQuery.Resolve(woundUid, ref woundComp, false))
-            return;
-
         var (woundableEnt, woundableComp) = woundable;
-        if (!WoundableQuery.Resolve(woundableEnt, ref woundableComp, false))
-            return;
 
         if (woundableComp.Wounds == null || !woundableComp.Wounds.Contains(woundUid))
             return;
@@ -302,12 +293,9 @@ public abstract partial class WoundSystem : EntitySystem
         RaiseLocalEvent(woundUid, ref ev);
     }
 
-    protected void UpdateWoundableIntegrity(Entity<WoundableComponent?> woundable)
+    protected void UpdateWoundableIntegrity(Entity<WoundableComponent> woundable)
     {
         var (uid, component) = woundable;
-        if (!WoundableQuery.Resolve(uid, ref component, false))
-            return;
-
         if (component.Wounds == null)
             return;
 
@@ -343,12 +331,9 @@ public abstract partial class WoundSystem : EntitySystem
         DirtyField(uid, component, nameof(WoundableComponent.WoundableIntegrity));
     }
 
-    protected void CheckWoundableSeverityThresholds(Entity<WoundableComponent?> woundable)
+    protected void CheckWoundableSeverityThresholds(Entity<WoundableComponent> woundable)
     {
         var (uid, component) = woundable;
-        if (!WoundableQuery.Resolve(uid, ref component, false))
-            return;
-
         var nearestSeverity = component.WoundableSeverity;
         foreach (var (severity, value) in component.Thresholds.OrderByDescending(kv => kv.Value))
         {
@@ -424,12 +409,13 @@ public abstract partial class WoundSystem : EntitySystem
             nameof(WoundableComponent.WoundableSeverity));
     }
 
-    protected void FixWoundableRoots(EntityUid targetEntity, WoundableComponent targetWoundable)
+    protected void FixWoundableRoots(Entity<WoundableComponent> woundable)
     {
+        var (targetEntity, targetWoundable) = woundable;
         if (targetWoundable.ChildWoundables.Count == 0)
             return;
 
-        foreach (var (childEntity, childWoundable) in GetAllWoundableChildren(targetEntity, targetWoundable))
+        foreach (var (childEntity, childWoundable) in GetAllWoundableChildren(woundable))
         {
             childWoundable.RootWoundable = targetWoundable.RootWoundable;
             DirtyField(childEntity, childWoundable, nameof(WoundableComponent.RootWoundable));
@@ -439,29 +425,30 @@ public abstract partial class WoundSystem : EntitySystem
     }
 
     protected void InternalAddWoundableToParent(
-        EntityUid parentEntity,
-        EntityUid childEntity,
-        WoundableComponent parentWoundable,
-        WoundableComponent childWoundable)
+        Entity<WoundableComponent> parentEntity,
+        Entity<WoundableComponent> childEntity)
     {
+        var (parentUid, parentWoundable) = parentEntity;
+        var (childUid, childWoundable) = childEntity;
+
         parentWoundable.ChildWoundables.Add(childEntity);
         childWoundable.ParentWoundable = parentEntity;
         childWoundable.RootWoundable = parentWoundable.RootWoundable;
 
-        FixWoundableRoots(childEntity, childWoundable);
+        FixWoundableRoots(childEntity);
 
         var woundableRoot = CompOrNull<WoundableComponent>(parentWoundable.RootWoundable) ?? parentWoundable;
-        var woundableAttached = new WoundableAttachedEvent(parentEntity, parentWoundable);
+        var woundableAttached = new WoundableAttachedEvent(parentUid, parentWoundable);
 
-        RaiseLocalEvent(childEntity, ref woundableAttached);
+        RaiseLocalEvent(childUid, ref woundableAttached);
 
-        foreach (var (woundId, wound) in GetAllWounds(childEntity, childWoundable))
+        foreach (var (woundId, wound) in GetAllWounds(childEntity))
         {
             var ev = new WoundAddedEvent(wound, parentWoundable, woundableRoot);
             RaiseLocalEvent(woundId, ref ev);
         }
 
-        DirtyFields(childEntity, childWoundable, null,
+        DirtyFields(childUid, childWoundable, null,
             nameof(WoundableComponent.ParentWoundable),
             nameof(WoundableComponent.RootWoundable),
             nameof(WoundableComponent.ChildWoundables));
@@ -471,31 +458,32 @@ public abstract partial class WoundSystem : EntitySystem
     }
 
     protected void InternalRemoveWoundableFromParent(
-        EntityUid parentEntity,
-        EntityUid childEntity,
-        WoundableComponent parentWoundable,
-        WoundableComponent childWoundable)
+        Entity<WoundableComponent> parentEntity,
+        Entity<WoundableComponent> childEntity)
     {
+        var (parentUid, parentWoundable) = parentEntity;
+        var (childUid, childWoundable) = childEntity;
+
         var removedFromParent = parentWoundable.ChildWoundables.Remove(childEntity);
 
-        if (TerminatingOrDeleted(childEntity) || TerminatingOrDeleted(parentEntity))
+        if (TerminatingOrDeleted(childUid) || TerminatingOrDeleted(parentUid))
         {
             if (removedFromParent && !TerminatingOrDeleted(parentEntity))
-                DirtyField(parentEntity, parentWoundable, nameof(WoundableComponent.ChildWoundables));
+                DirtyField(parentUid, parentWoundable, nameof(WoundableComponent.ChildWoundables));
 
             return;
         }
         childWoundable.ParentWoundable = null;
         childWoundable.RootWoundable = childEntity;
 
-        FixWoundableRoots(childEntity, childWoundable);
+        FixWoundableRoots(childEntity);
 
         var oldWoundableRoot = WoundableQuery.Comp(parentWoundable.RootWoundable);
         var woundableDetached = new WoundableDetachedEvent(parentEntity, parentWoundable);
 
         RaiseLocalEvent(childEntity, ref woundableDetached);
 
-        foreach (var (woundId, wound) in GetAllWounds(childEntity, childWoundable))
+        foreach (var (woundId, wound) in GetAllWounds(childEntity))
         {
             var ev = new WoundRemovedEvent(wound, childWoundable, oldWoundableRoot);
             RaiseLocalEvent(woundId, ref ev);
@@ -504,11 +492,11 @@ public abstract partial class WoundSystem : EntitySystem
             RaiseLocalEvent(childWoundable.RootWoundable, ref ev2);
         }
 
-        DirtyFields(childEntity, childWoundable, null,
+        DirtyFields(childUid, childWoundable, null,
             nameof(WoundableComponent.ParentWoundable),
             nameof(WoundableComponent.RootWoundable),
             nameof(WoundableComponent.ChildWoundables));
-        DirtyFields(parentEntity, parentWoundable, null,
+        DirtyFields(parentUid, parentWoundable, null,
             nameof(WoundableComponent.ChildWoundables),
             nameof(WoundableComponent.RootWoundable));
     }
@@ -548,18 +536,15 @@ public abstract partial class WoundSystem : EntitySystem
         }
     }
 
-    protected void DestroyWoundableChildren(EntityUid woundableEntity, WoundableComponent? woundableComp = null)
+    protected void DestroyWoundableChildren(Entity<WoundableComponent> woundableEntity)
     {
-        if (!WoundableQuery.Resolve(woundableEntity, ref woundableComp, false))
-            return;
-
-        foreach (var (child, childWoundable) in GetAllWoundableChildren(woundableEntity, woundableComp))
+        var (uid, _) = woundableEntity;
+        foreach (var (child, childWoundable) in GetAllWoundableChildren(woundableEntity))
         {
-            if (child == woundableEntity || TerminatingOrDeleted(child))
+            if (child == uid || TerminatingOrDeleted(child))
                 continue;
 
-            var parent = childWoundable.ParentWoundable ?? woundableEntity;
-
+            var parent = childWoundable.ParentWoundable ?? uid;
             if (childWoundable.WoundableSeverity is WoundableSeverity.Critical)
             {
                 DestroyWoundable(parent, child, childWoundable);

--- a/Content.Shared/Backmen/Surgery/Wounds/Systems/WoundSystem.cs
+++ b/Content.Shared/Backmen/Surgery/Wounds/Systems/WoundSystem.cs
@@ -182,10 +182,12 @@ public abstract partial class WoundSystem : EntitySystem
             var bodySeverity = FixedPoint2.Zero;
             if (TryGetWoundableBody(ent, out var bodyUid) && TryComp<BodyComponent>(bodyUid, out var bodyComp))
             {
-                foreach (var woundable in Body.GetWoundableTargets(bodyUid, bodyComp))
-                {
-                    bodySeverity += GetWoundableIntegrityDamage(woundable);
-                }
+                // TODO: the hell
+                bodySeverity =
+                    Body.GetWoundableTargets(bodyUid, bodyComp)
+                        .Aggregate(bodySeverity,
+                            (current, woundable)
+                            => current + GetWoundableIntegrityDamage((woundable, Comp<WoundableComponent>(woundable))));
 
                 var ev1 = new WoundableIntegrityChangedOnBodyEvent(
                     ent,
@@ -241,9 +243,10 @@ public abstract partial class WoundSystem : EntitySystem
         wound.NetworkedDamageGroup = damageGroup?.ID;
     }
 
-    protected void CheckSeverityThresholds(EntityUid wound, WoundComponent? component = null)
+    protected void CheckSeverityThresholds(Entity<WoundComponent?> wound)
     {
-        if (!WoundQuery.Resolve(wound, ref component, false))
+        var (uid, component) = wound;
+        if (!WoundQuery.Resolve(uid, ref component, false))
             return;
 
         var nearestSeverity = component.WoundSeverity;
@@ -259,48 +262,53 @@ public abstract partial class WoundSystem : EntitySystem
         if (nearestSeverity != component.WoundSeverity)
         {
             var ev = new WoundSeverityChangedEvent(component.WoundSeverity, nearestSeverity);
-            RaiseLocalEvent(wound, ref ev);
+            RaiseLocalEvent(uid, ref ev);
         }
         component.WoundSeverity = nearestSeverity;
 
         if (!TerminatingOrDeleted(wound))
-            DirtyField(wound, component, nameof(WoundComponent.WoundSeverity));
+            DirtyField(uid, component, nameof(WoundComponent.WoundSeverity));
     }
 
     // NOTE: THIS SHOULD BE ONLY RAISED ON A CHANGE OF VALUES. OUTSIDE OF CLASSICAL DAMAGE HANDLING LIKE HEALING
-    protected void RaiseWoundEvents(EntityUid uid,
-        EntityUid woundableEnt,
-        WoundComponent wound,
-        FixedPoint2 oldSeverity,
-        WoundableComponent? woundableComp = null)
+    protected void RaiseWoundEvents(
+        Entity<WoundComponent?> woundEnt,
+        Entity<WoundableComponent?> woundable,
+        FixedPoint2 oldSeverity)
     {
-        if (!WoundableQuery.Resolve(woundableEnt, ref woundableComp, false) || woundableComp.Wounds == null)
+        var (woundUid, woundComp) = woundEnt;
+        if (!WoundQuery.Resolve(woundUid, ref woundComp, false))
             return;
 
-        if (!woundableComp.Wounds.Contains(uid))
+        var (woundableEnt, woundableComp) = woundable;
+        if (!WoundableQuery.Resolve(woundableEnt, ref woundableComp, false))
             return;
 
-        var delta = wound.WoundSeverityPoint - oldSeverity;
+        if (!woundableComp.Wounds.Contains(woundUid))
+            return;
+
+        var delta = woundComp.WoundSeverityPoint - oldSeverity;
         var damageSpec = new DamageSpecifier();
 
-        damageSpec.DamageDict.Add(wound.DamageType, delta);
+        damageSpec.DamageDict.Add(woundComp.DamageType, delta);
 
-        var woundChangedEvent = new WoundChangedEvent(wound, delta);
-        RaiseLocalEvent(uid, ref woundChangedEvent);
+        var woundChangedEvent = new WoundChangedEvent(woundComp, delta);
+        RaiseLocalEvent(woundUid, ref woundChangedEvent);
 
         // Raise woundable effects without computing the severity changes, so we do not accidentally duplicate the severity.
-        GetWoundsChanged(woundableEnt, woundableEnt, damageSpec, false, woundableComp);
+        GetWoundsChanged(woundable, woundableEnt, damageSpec, false);
 
-        var ev = new WoundSeverityPointChangedEvent(wound, oldSeverity, wound.WoundSeverityPoint);
-        RaiseLocalEvent(uid, ref ev);
+        var ev = new WoundSeverityPointChangedEvent(woundComp, oldSeverity, woundComp.WoundSeverityPoint);
+        RaiseLocalEvent(woundUid, ref ev);
     }
 
-    protected void UpdateWoundableIntegrity(EntityUid uid, WoundableComponent? component = null)
+    protected void UpdateWoundableIntegrity(Entity<WoundableComponent?> woundable)
     {
-        if (!WoundableQuery.Resolve(uid, ref component, false) || component.Wounds == null)
+        var (uid, component) = woundable;
+        if (!WoundableQuery.Resolve(uid, ref component, false))
             return;
 
-        // Ignore scars for woundable integrity.. Unless you want to confuse people with minor woundable state
+        // Ignore scars for woundable integrity.. Unless you want to confuse people with a minor woundable state
         var damage =
             component.Wounds.ContainedEntities.Select(WoundQuery.Comp)
                 .Where(wound => !wound.IsScar)
@@ -318,7 +326,8 @@ public abstract partial class WoundSystem : EntitySystem
         {
             bodySeverity = Body.GetWoundableTargets(bodyUid, bodyComp)
                 .Aggregate(bodySeverity,
-                    (current, woundable) => current + GetWoundableIntegrityDamage(woundable));
+                    (current, target) =>
+                        current + GetWoundableIntegrityDamage((target, Comp<WoundableComponent>(target))));
 
             var ev1 = new WoundableIntegrityChangedOnBodyEvent(
                 (uid, component),
@@ -331,9 +340,10 @@ public abstract partial class WoundSystem : EntitySystem
         DirtyField(uid, component, nameof(WoundableComponent.WoundableIntegrity));
     }
 
-    protected void CheckWoundableSeverityThresholds(EntityUid woundable, WoundableComponent? component = null)
+    protected void CheckWoundableSeverityThresholds(Entity<WoundableComponent?> woundable)
     {
-        if (!WoundableQuery.Resolve(woundable, ref component, false))
+        var (uid, component) = woundable;
+        if (!WoundableQuery.Resolve(uid, ref component, false))
             return;
 
         var nearestSeverity = component.WoundableSeverity;

--- a/Content.Shared/Backmen/Surgery/Wounds/Systems/WoundSystem.cs
+++ b/Content.Shared/Backmen/Surgery/Wounds/Systems/WoundSystem.cs
@@ -284,7 +284,7 @@ public abstract partial class WoundSystem : EntitySystem
         if (!WoundableQuery.Resolve(woundableEnt, ref woundableComp, false))
             return;
 
-        if (!woundableComp.Wounds.Contains(woundUid))
+        if (woundableComp.Wounds == null || !woundableComp.Wounds.Contains(woundUid))
             return;
 
         var delta = woundComp.WoundSeverityPoint - oldSeverity;
@@ -306,6 +306,9 @@ public abstract partial class WoundSystem : EntitySystem
     {
         var (uid, component) = woundable;
         if (!WoundableQuery.Resolve(uid, ref component, false))
+            return;
+
+        if (component.Wounds == null)
             return;
 
         // Ignore scars for woundable integrity.. Unless you want to confuse people with a minor woundable state

--- a/Content.Shared/Body/BodyComponent.cs
+++ b/Content.Shared/Body/BodyComponent.cs
@@ -17,6 +17,9 @@ public sealed partial class BodyComponent : Component
     /// </summary>
     [ViewVariables]
     public Container? Organs;
+
+    // backmen-edit
+    [ViewVariables, DataField] public bool ComplexBody;
 }
 
 /// <summary>

--- a/Content.Shared/Body/BodyComponent.cs
+++ b/Content.Shared/Body/BodyComponent.cs
@@ -17,9 +17,6 @@ public sealed partial class BodyComponent : Component
     /// </summary>
     [ViewVariables]
     public Container? Organs;
-
-    // backmen-edit
-    [ViewVariables, DataField] public bool ComplexBody;
 }
 
 /// <summary>

--- a/Content.Shared/Body/Systems/SharedBloodstreamSystem.cs
+++ b/Content.Shared/Body/Systems/SharedBloodstreamSystem.cs
@@ -195,7 +195,8 @@ public abstract partial class SharedBloodstreamSystem : EntitySystem
         var total = FixedPoint2.Zero;
         foreach (var bodyPart in _body.GetDistributedDamageTargets(entity.Owner))
         {
-            foreach (var wound in _wound.GetWoundableWoundsWithComp<BleedInflicterComponent>(bodyPart))
+            foreach (var wound in
+                     _wound.GetWoundableWoundsWithCompNullable<BleedInflicterComponent>(bodyPart))
             {
                 // start-backmen: tourniquet-bleeding-display
                 if (!CanWoundBleed((wound, wound.Comp2)) || wound.Comp2.BleedingAmount <= 0)

--- a/Content.Shared/Medical/Healing/HealingSystem.cs
+++ b/Content.Shared/Medical/Healing/HealingSystem.cs
@@ -268,7 +268,7 @@ public sealed partial class HealingSystem : EntitySystem
                 : wound.Comp.WoundSeverityPoint;
 
             // TODO: When I rework the bloodstream system, I will also rework the healing logic
-            _wounds.ApplyWoundSeverity(wound, value, wound);
+            _wounds.ApplyWoundSeverity(wound.AsNullable(), value);
             break;
         }
 

--- a/Content.Shared/Medical/Healing/HealingSystem.cs
+++ b/Content.Shared/Medical/Healing/HealingSystem.cs
@@ -28,7 +28,6 @@ using Content.Shared.Backmen.Surgery.Wounds.Components;
 using Content.Shared.Backmen.Surgery.Wounds.Systems;
 using Content.Shared.Backmen.Targeting;
 using Robust.Shared.Audio;
-using Robust.Shared.GameObjects;
 
 namespace Content.Shared.Medical.Healing;
 
@@ -154,6 +153,65 @@ public sealed partial class HealingSystem : EntitySystem
     }
 
     // start-backmen: healing-fallback
+    private bool AreHealableWoundsPresent(
+        Entity<WoundableComponent> woundable,
+        HealingComponent healing,
+        EntityUid body,
+        EntityUid user)
+    {
+        var healableWoundsPresent = false;
+        var bleedingWounds = 0;
+        var nonhealableWounds = 0;
+        foreach (var wound in _wounds.GetWoundableWounds(woundable, woundable))
+        {
+            if (TryComp(wound, out BleedInflicterComponent? bleeds))
+            {
+                if (bleeds.IsBleeding && bleeds.BleedingAmount > healing.UnableToHealBleedsThreshold)
+                {
+                    bleedingWounds++;
+                    continue;
+                }
+
+                healableWoundsPresent = true;
+                break;
+            }
+
+            if (!healing.Damage.DamageDict.ContainsKey(wound.Comp.DamageType))
+            {
+                nonhealableWounds++;
+                continue;
+            }
+
+            if (!_wounds.CanHealWound(wound, wound))
+                continue;
+
+            healableWoundsPresent = true;
+            break;
+        }
+
+        if (nonhealableWounds > 0)
+        {
+            var popup = Loc.GetString("medical-item-no-healable-damage", ("target", body));
+            if (_trauma.AnyTraumasBlockingHealing(woundable, woundable))
+            {
+                popup = Loc.GetString("medical-item-requires-partial-surgery-rebell", ("target", body));
+            }
+            else
+            {
+                if (bleedingWounds > nonhealableWounds)
+                    popup = Loc.GetString("medical-item-cant-use-bleeding-heavy", ("target", body));
+            }
+
+            _popupSystem.PopupPredicted(
+                popup,
+                body,
+                user,
+                PopupType.MediumCaution);
+        }
+
+        return healableWoundsPresent;
+    }
+
     private void OnBodyDoAfter(EntityUid ent, BodyComponent comp, ref HealingDoAfterEvent args)
     {
         if (args.Target == null || !TryComp(args.Used, out HealingComponent? healing))
@@ -163,19 +221,17 @@ public sealed partial class HealingSystem : EntitySystem
             return;
 
         EntityUid targetedWoundable;
-        Dictionary<string, FixedPoint2> stuffToHeal;
-
-        if (TryGetEntity(args.TargetWoundable, out var resolvedWoundable) && resolvedWoundable != null)
+        if (!TryGetEntity(args.TargetWoundable, out var potentialWoundable))
         {
-            targetedWoundable = resolvedWoundable.Value;
-            stuffToHeal = healing.Damage.DamageDict
-                .Where(damage => _wounds.HasDamageOfType(targetedWoundable, damage.Key))
-                .ToDictionary(damage => damage.Key.Id, damage => damage.Value);
+            if (!_medicalTarget.TryResolveHealTarget(ent, args.User, healing, out targetedWoundable, out _, out _))
+            {
+                args.Handled = true;
+                return;
+            }
         }
-        else if (!_medicalTarget.TryResolveHealTarget(ent, args.User, healing, out targetedWoundable, out stuffToHeal, out _))
+        else
         {
-            args.Handled = true;
-            return;
+            targetedWoundable = potentialWoundable.Value;
         }
 
         if (!TryComp<WoundableComponent>(targetedWoundable, out var woundableComp))
@@ -184,100 +240,62 @@ public sealed partial class HealingSystem : EntitySystem
             return;
         }
 
-        var totalBleeds = _medicalTarget.GetTotalBleeds(targetedWoundable, woundableComp);
+        // TODO: When complex bloodstream is implemented, rework adding blood
+        if (healing.ModifyBloodLevel != 0)
+            _bloodstreamSystem.TryModifyBloodLevel(ent, healing.ModifyBloodLevel);
 
-        var woundableDamageContainer = woundableComp.DamageContainer;
-        if (healing.DamageContainers != null && woundableDamageContainer.HasValue &&
-            !healing.DamageContainers.Contains(woundableDamageContainer.Value))
+        var healed = FixedPoint2.Zero;
+        foreach (var wound in _wounds.GetWoundableWounds(targetedWoundable, woundableComp))
         {
-            _popupSystem.PopupEntity(
-                Loc.GetString("cant-heal-damage-rebell", ("target", ent), ("used", args.Used)),
-                ent,
-                args.User,
-                PopupType.Medium);
-            args.Handled = true;
-            return;
-        }
-
-        var dontRepeat = false;
-        var bleedsManipulated = false;
-
-        var bleedStopAbility = FixedPoint2.New(-healing.BloodlossModifier);
-        if (totalBleeds > healing.UnableToHealBleedsThreshold
-            && (healing.BloodlossModifier != 0 || stuffToHeal.Count == 0))
-        {
-            _popupSystem.PopupEntity(
-                Loc.GetString("medical-item-cant-use-bleeding-heavy", ("target", ent)),
-                ent,
-                args.User,
-                PopupType.MediumCaution);
-            args.Handled = true;
-            return;
-        }
-
-        if (healing.BloodlossModifier != 0)
-        {
-            foreach (var wound in _wounds.GetWoundableWoundsWithComp<BleedInflicterComponent>(targetedWoundable, woundableComp))
+            if (TryComp(wound, out BleedInflicterComponent? bleeds))
             {
-                var bleeds = wound.Comp2;
-                if (!bleeds.IsBleeding)
+                if (bleeds.IsBleeding && bleeds.BleedingAmount > healing.UnableToHealBleedsThreshold)
                     continue;
 
-                if (bleedStopAbility > bleeds.BleedingAmount)
-                {
-                    bleedStopAbility -= bleeds.BleedingAmountRaw;
+                // TODO: this will be reworked along with complex bloodstream system
+                bleeds.BleedingAmountRaw = 0;
+                bleeds.SeverityPenalty = 0;
+                bleeds.ScalingLimit = 0;
 
-                    bleeds.BleedingAmountRaw = 0;
-                    bleeds.Scaling = 0;
-
-                    bleeds.IsBleeding = false;
-                }
-                else
-                {
-                    bleeds.BleedingAmountRaw -= bleedStopAbility;
-                }
+                bleeds.IsBleeding = false;
             }
-        }
 
-        var isBleeding = -healing.BloodlossModifier != bleedStopAbility;
-        if (!isBleeding)
-        {
-            _wounds.TryHaltAllBleeding(targetedWoundable, woundableComp);
-            if (healing.ModifyBloodLevel != 0)
-            {
-                _bloodstreamSystem.TryModifyBloodLevel(ent, healing.ModifyBloodLevel);
-                bleedsManipulated = true;
-            }
-        }
-
-        var healedTotal = FixedPoint2.Zero;
-        foreach (var (key, value) in stuffToHeal)
-        {
-            if (!_wounds.TryHealWoundsOnWoundable(targetedWoundable, -value, key, out var healed, woundableComp))
+            if (!healing.Damage.DamageDict.TryGetValue(wound.Comp.DamageType, out var value))
                 continue;
 
-            healedTotal += healed;
+            healed = wound.Comp.WoundSeverityPoint > value
+                ? value
+                : wound.Comp.WoundSeverityPoint;
+
+            // TODO: When I rework the bloodstream system, I will also rework the healing logic
+            _wounds.ApplyWoundSeverity(wound, value, wound);
+            break;
         }
 
-        if (healedTotal <= 0 && !bleedsManipulated)
+        if (healed == FixedPoint2.Zero)
         {
-            string popup;
-            if (_trauma.AnyTraumasBlockingHealing(targetedWoundable, woundableComp))
-                popup = Loc.GetString("medical-item-requires-surgery-rebell", ("target", args.Target));
-            else if (totalBleeds > healing.UnableToHealBleedsThreshold && healing.BloodlossModifier != 0)
-                popup = Loc.GetString("medical-item-cant-use-bleeding-heavy", ("target", args.Target));
-            else
-                popup = Loc.GetString("medical-item-no-healable-damage", ("target", args.Target));
-
-            _popupSystem.PopupEntity(
-                popup,
+            _popupSystem.PopupPredicted(
+                Loc.GetString("medical-item-no-healable-damage", ("target", args.Target)),
                 args.Target.Value,
                 args.User,
                 PopupType.MediumCaution);
             args.Handled = true;
-            return;
         }
 
+        //var woundableDamageContainer = woundableComp.DamageContainer;
+        //if (healing.DamageContainers != null && woundableDamageContainer.HasValue &&
+        //    !healing.DamageContainers.Contains(woundableDamageContainer.Value))
+        //{
+        //    _popupSystem.PopupPredicted(
+        //        Loc.GetString("cant-heal-damage-rebell", ("target", ent), ("used", args.Used)),
+        //        ent,
+        //        args.User,
+        //        PopupType.Medium);
+        //    args.Handled = true;
+        //    return;
+        //}
+
+        var dontRepeat = false;
         if (TryComp<StackComponent>(args.Used.Value, out var stackComp))
         {
             if(!_stacks.TryUse((args.Used.Value,stackComp), 1))
@@ -297,29 +315,24 @@ public sealed partial class HealingSystem : EntitySystem
         if (ent != args.User)
         {
             _adminLogger.Add(LogType.Healed,
-                $"{ToPrettyString(args.User):user} healed {ToPrettyString(ent):target} for {healedTotal:damage} damage");
+                $"{ToPrettyString(args.User):user} healed {ToPrettyString(ent):target} for {healed:damage} damage");
         }
         else
         {
             _adminLogger.Add(LogType.Healed,
-                $"{ToPrettyString(args.User):user} healed themselves for {healedTotal:damage} damage");
+                $"{ToPrettyString(args.User):user} healed themselves for {healed:damage} damage");
         }
 
         _audio.PlayPvs(healing.HealingEndSound, ent, AudioParams.Default.WithVariation(0.125f).WithVolume(1f));
 
-        args.Repeat = IsBodyDamaged((ent, comp), args.User, (args.Used.Value, healing), false) && !dontRepeat;
+        args.Repeat =
+            AreHealableWoundsPresent((targetedWoundable, woundableComp), healing, ent, args.User)
+            && !dontRepeat;
         args.Handled = true;
 
         if (args.Repeat)
             return;
-
-        if (_trauma.AnyTraumasBlockingHealing(targetedWoundable, woundableComp))
-        {
-            _popupSystem.PopupEntity(Loc.GetString("medical-item-requires-partial-surgery-rebell", ("target", ent)), ent, args.User, PopupType.MediumCaution);
-            return;
-        }
-
-        _popupSystem.PopupEntity(Loc.GetString("medical-item-finished-using", ("item", args.Used)), ent, args.User, PopupType.Medium);
+        _popupSystem.PopupPredicted(Loc.GetString("medical-item-finished-using", ("item", args.Used)), ent, args.User, PopupType.Medium);
     }
     // end-backmen: healing-fallback
 
@@ -354,66 +367,6 @@ public sealed partial class HealingSystem : EntitySystem
 
         return false;
     }
-
-    // start-backmen: healing-fallback
-    private bool IsBodyDamaged(Entity<BodyComponent> target, EntityUid user, Entity<HealingComponent> healing, bool throwPopups = true)
-    {
-        if (!HasComp<ConsciousnessComponent>(target))
-            return false;
-
-        if (_medicalTarget.TryResolveHealTarget(target, user, healing.Comp, out _, out _, out _))
-            return true;
-
-        if (!throwPopups)
-            return false;
-
-        if (!TryComp<TargetingComponent>(user, out var targeting))
-            return false;
-
-        var (partType, symmetry) = _bodySystem.ConvertTargetBodyPart(targeting.Target);
-        if (!_bodySystem.TryGetWoundableTargetByType(target, partType, symmetry, out var targetedWoundable))
-        {
-            _popupSystem.PopupEntity(Loc.GetString("does-not-exist-rebell"), target, user, PopupType.MediumCaution);
-            return false;
-        }
-
-        if (!TryComp<WoundableComponent>(targetedWoundable, out var woundableComp))
-            return false;
-
-        var totalBleeds = _medicalTarget.GetTotalBleeds(targetedWoundable, woundableComp);
-        var stuffToHeal = healing.Comp.Damage.DamageDict
-            .Where(damage => _wounds.HasDamageOfType(targetedWoundable, damage.Key))
-            .ToDictionary(damage => damage.Key, damage => damage.Value);
-
-        if (totalBleeds > healing.Comp.UnableToHealBleedsThreshold
-            && (healing.Comp.BloodlossModifier != 0 || stuffToHeal.Count == 0))
-        {
-            _popupSystem.PopupEntity(
-                Loc.GetString("medical-item-cant-use-bleeding-heavy", ("target", target)),
-                target,
-                user,
-                PopupType.MediumCaution);
-        }
-        else if (_trauma.AnyTraumasBlockingHealing(targetedWoundable, woundableComp))
-        {
-            _popupSystem.PopupEntity(
-                Loc.GetString("medical-item-requires-surgery-rebell", ("target", target)),
-                target,
-                user,
-                PopupType.MediumCaution);
-        }
-        else
-        {
-            _popupSystem.PopupEntity(
-                Loc.GetString("medical-item-no-healable-damage", ("target", target)),
-                target,
-                user,
-                PopupType.MediumCaution);
-        }
-
-        return false;
-    }
-    // end-backmen: healing-fallback
 
     private void OnHealingUse(Entity<HealingComponent> healing, ref UseInHandEvent args)
     {
@@ -456,10 +409,26 @@ public sealed partial class HealingSystem : EntitySystem
         if (TryComp<StackComponent>(healing, out var stack) && stack.Count < 1)
             return false;
 
+        // start-backmen: medical-targeting
+        var healingEvent = new HealingDoAfterEvent();
+        EntityUid targetWoundable = default;
+        if (TryComp<BodyComponent>(target, out _)
+            && HasComp<ConsciousnessComponent>(target)
+            && _medicalTarget.TryResolveHealTarget(target, user, healing.Comp, out var woundable, out _, out _))
+        {
+            healingEvent.TargetWoundable = GetNetEntity(woundable);
+            targetWoundable = woundable;
+        }
+        // end-backmen: medical-targeting
+
         var anythingToDo =
             HasDamage(healing, target!) ||
-            (TryComp<BodyComponent>(target, out var bodyComp) &&
-             IsBodyDamaged((target, bodyComp), user, healing)) ||
+            (HasComp<ConsciousnessComponent>(target) && targetWoundable != default &&
+             AreHealableWoundsPresent(
+                 (targetWoundable, Comp<WoundableComponent>(targetWoundable)),
+                     healing.Comp,
+                     target.Owner,
+                 user)) ||
             healing.Comp.ModifyBloodLevel > 0 // Special case if healing item can restore lost blood...
                 && TryComp<BloodstreamComponent>(target, out var bloodstream)
                 && _solutionContainerSystem.ResolveSolution(target.Owner, bloodstream.BloodSolutionName, ref bloodstream.BloodSolution, out var bloodSolution)
@@ -484,16 +453,6 @@ public sealed partial class HealingSystem : EntitySystem
         var delay = isNotSelf
             ? healing.Comp.Delay
             : healing.Comp.Delay * GetScaledHealingPenalty(target, healing.Comp.SelfHealPenaltyMultiplier);
-
-        // start-backmen: medical-targeting
-        var healingEvent = new HealingDoAfterEvent();
-        if (TryComp<BodyComponent>(target, out _)
-            && HasComp<ConsciousnessComponent>(target)
-            && _medicalTarget.TryResolveHealTarget(target, user, healing.Comp, out var woundable, out _, out _))
-        {
-            healingEvent.TargetWoundable = GetNetEntity(woundable);
-        }
-        // end-backmen: medical-targeting
 
         var doAfterEventArgs =
             new DoAfterArgs(EntityManager, user, delay, healingEvent, target, target: target, used: healing)

--- a/Resources/Prototypes/_Backmen/Entities/Surgery/wounds.yml
+++ b/Resources/Prototypes/_Backmen/Entities/Surgery/wounds.yml
@@ -21,6 +21,7 @@
     woundVisibility: Always
     scarWound: BluntScar
     integrityMultiplier: 0.3 #heheheha
+    mergeChance: 0.2
   - type: TraumaInflicter
     severityThreshold: 12
     allowedTraumas:
@@ -58,6 +59,7 @@
     woundVisibility: Always
     scarWound: PiercingScar
     integrityMultiplier: 0.12
+    mergeChance: 0.07
   - type: TraumaInflicter
     severityThreshold: 12
     allowedTraumas:
@@ -94,6 +96,7 @@
     woundVisibility: Always
     scarWound: PiercingScar
     integrityMultiplier: 0.05
+    mergeChance: 0.04
   - type: TraumaInflicter
     severityThreshold: 6
     allowedTraumas:
@@ -127,6 +130,7 @@
     woundVisibility: Always
     scarWound: SlashScar
     integrityMultiplier: 0.17
+    mergeChance: 0.15
   - type: TraumaInflicter
     severityThreshold: 9
     allowedTraumas:
@@ -162,6 +166,7 @@
     woundVisibility: Always
     scarWound: BurnScar
     integrityMultiplier: 0.21 # boiling people
+    mergeChance: 0.5
   - type: TraumaInflicter
     severityThreshold: 24
     allowedTraumas:
@@ -198,6 +203,7 @@
     woundVisibility: Always
     scarWound: BurnScar
     integrityMultiplier: 0.01
+    mergeChance: 0.5
   - type: TraumaInflicter
     severityThreshold: 12
     allowedTraumas:
@@ -225,6 +231,7 @@
     woundVisibility: AdvancedScanner
     scarWound: BurnScar
     integrityMultiplier: 0.1
+    mergeChance: 1
   - type: TraumaInflicter
     severityThreshold: 0
     allowedTraumas:
@@ -253,6 +260,7 @@
     woundVisibility: AdvancedScanner
     scarWound: BurnScar
     integrityMultiplier: 0 # Rotting does not gib people
+    mergeChance: 1
   - type: TraumaInflicter
     severityThreshold: 12
     allowedTraumas:
@@ -279,6 +287,7 @@
     woundVisibility: HandScanner
     scarWound: RadiationScar
     integrityMultiplier: 0.06
+    mergeChance: 1
   - type: TraumaInflicter
     severityThreshold: 11
     allowedTraumas:
@@ -334,6 +343,7 @@
     woundType: Internal
     woundVisibility: AdvancedScanner
     integrityMultiplier: 0
+    mergeChance: 1
   - type: PainInflicter
     painType: TraumaticPain
     multiplier: 0.333
@@ -349,6 +359,7 @@
     woundVisibility: HandScanner
     scarWound: BurnScar
     integrityMultiplier: 0.07
+    mergeChance: 0.3
   - type: TraumaInflicter
     severityThreshold: 9
     allowedTraumas:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Lechenie teper rabotaet adekvatno
Povischena vischivaemost lyudey, nebolschaya pererabotka woundov
<!-- What did you change? -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!--
:cl:
- tweak: Woundi teper ne stackayutsya, chto relyativno ponischaet schans na kriticheskie povreschdeniya
- fix: Ispravleno lechenie
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Новые возможности**
  - Добавлена вероятность автоматического объединения новых ран с уже существующими; в расчёте учитываются тяжесть и шанс конкретной раны.
  - Вероятность объединения теперь регулируется серверным параметром `wounding.wound_merge_ratio`.

- **Исправления**
  - Исправлено изменение тяжести при повторных повреждениях/лечении: оно корректно ограничивается снизу нулём.
  - Лечение точнее выбирает, какие раны можно исцелять, и корректнее обрабатывает кровотечения по порогам; повторное лечение корректно прекращается, когда подходящих повреждений больше нет.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->